### PR TITLE
Task00 Шарипов Дениль СПбГУ

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,18 @@ void reportError(cl_int err, const std::string &filename, int line) {
 
 #define OCL_SAFE_CALL(expr) reportError(expr, __FILE__, __LINE__)
 
+std::string deviceTypeToString(cl_device_type deviceType) {
+    switch (deviceType) {
+        case CL_DEVICE_TYPE_CPU:
+            return "cpu";
+        case CL_DEVICE_TYPE_GPU:
+            return "gpu";
+        case CL_DEVICE_TYPE_ACCELERATOR:
+            return "accelerator";
+        default:
+            return "unknown";
+    }
+}
 
 int main() {
     // Пытаемся слинковаться с символами OpenCL API в runtime (через библиотеку libs/clew)
@@ -60,7 +72,7 @@ int main() {
         // Откройте таблицу с кодами ошибок:
         // libs/clew/CL/cl.h:103
         // P.S. Быстрый переход к файлу в CLion: Ctrl+Shift+N -> cl.h (или даже с номером строки: cl.h:103) -> Enter
-        // Найдите там нужный код ошибки и ее название
+        // Найдите там нужный код ошибки и ее название (-30: CL_INVALID_VALUE)
         // Затем откройте документацию по clGetPlatformInfo и в секции Errors найдите ошибку, с которой столкнулись
         // в документации подробно объясняется, какой ситуации соответствует данная ошибка, и это позволит, проверив код, понять, чем же вызвана данная ошибка (некорректным аргументом param_name)
         // Обратите внимание, что в этом же libs/clew/CL/cl.h файле указаны всевоможные defines, такие как CL_DEVICE_TYPE_GPU и т.п.
@@ -68,23 +80,66 @@ int main() {
         // TODO 1.2
         // Аналогично тому, как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
         std::vector<unsigned char> platformName(platformNameSize, 0);
-        // clGetPlatformInfo(...);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), nullptr));
         std::cout << "    Platform name: " << platformName.data() << std::endl;
 
         // TODO 1.3
         // Запросите и напечатайте так же в консоль вендора данной платформы
+        size_t platformVendorSize = 0;
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &platformVendorSize));
+
+        std::vector<unsigned char> platformVendor(platformNameSize, 0);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, platformVendorSize, platformVendor.data(), nullptr));
+        std::cout << "    Platform vendor: " << platformVendor.data() << std::endl;
 
         // TODO 2.1
         // Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
         cl_uint devicesCount = 0;
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
 
+        std::vector<cl_device_id> devices(devicesCount);
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, devices.data(), nullptr));
+  
         for (int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex) {
+            std::cout << "    Device #" << (deviceIndex + 1) << "/" << devicesCount << std::endl;
+            cl_device_id device = devices[deviceIndex];
+
             // TODO 2.2
             // Запросите и напечатайте в консоль:
             // - Название устройства
             // - Тип устройства (видеокарта/процессор/что-то странное)
             // - Размер памяти устройства в мегабайтах
             // - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+
+            size_t deviceNameSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, 0, nullptr, &deviceNameSize));
+
+            std::vector<unsigned char> deviceName(deviceNameSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, deviceName.size(), deviceName.data(), nullptr));
+            std::cout << "       Device name: " << deviceName.data() << std::endl;
+
+            cl_ulong localMemSize;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(cl_ulong), &localMemSize, nullptr));
+            std::cout << "       Device local mem size: " << localMemSize << " bytes" << std::endl;
+
+            cl_ulong globalMemSize;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(cl_ulong), &globalMemSize, nullptr));
+            std::cout << "       Device global mem size: " << globalMemSize / (1024 * 1024) << " Mb" << std::endl;
+
+            size_t deviceVersionSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VERSION, 0, nullptr, &deviceVersionSize));
+
+            std::vector<unsigned char> deviceVersion(deviceVersionSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VERSION, deviceVersion.size(), deviceVersion.data(), nullptr));
+            std::cout << "       Device version: " << deviceVersion.data() << std::endl;
+
+            cl_uint deviceAddressBits;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_ADDRESS_BITS, sizeof(cl_uint), &deviceAddressBits, nullptr));
+            std::cout << "       Device address bits: " << deviceAddressBits << std::endl;
+
+            cl_bool deviceAvailable;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_AVAILABLE, sizeof(cl_bool), &deviceAvailable, nullptr));
+            std::cout << "       Device available: " << deviceAvailable << std::endl;
         }
     }
 


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) CPU Runtime for OpenCL(TM) Applications
    Platform vendor: Intel(R) Corporation
    Device #1/1
       Device name: Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz
       Device local mem size: 32768 bytes
       Device global mem size: 48182 Mb
       Device version: OpenCL 2.1 (Build 0)
       Device address bits: 64
       Device available: 1
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./enumDevices
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: 
The command "./enumDevices" exited with 0.
</pre>

</p></details>