### PR TITLE
Task00 Данил Конев SPbU

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,8 +53,7 @@ int main() {
         // Не забывайте проверять коды ошибок с помощью макроса OCL_SAFE_CALL
         size_t platformNameSize = 0;
         OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, 0, nullptr, &platformNameSize));
-        // TODO 1.1
-        // Попробуйте вместо CL_PLATFORM_NAME передать какое-нибудь случайное число - например 239
+        // Попробуйте вместо CL_PLATFORM_NAME передать какое-нибудь случайное число - например 30
         // Т.к. это некорректный идентификатор параметра платформы - то метод вернет код ошибки
         // Макрос OCL_SAFE_CALL заметит это, и кинет ошибку с кодом
         // Откройте таблицу с кодами ошибок:
@@ -68,15 +67,26 @@ int main() {
         // TODO 1.2
         // Аналогично тому, как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
         std::vector<unsigned char> platformName(platformNameSize, 0);
-        // clGetPlatformInfo(...);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), nullptr));
         std::cout << "    Platform name: " << platformName.data() << std::endl;
 
         // TODO 1.3
-        // Запросите и напечатайте так же в консоль вендора данной платформы
+        size_t platformVendorSize = 0;
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &platformVendorSize));
+
+        std::vector<unsigned char> platformVendor(platformVendorSize, 0);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, platformVendorSize, platformVendor.data(), nullptr));
+        std::cout << "    Vendor: " << platformVendor.data() << std::endl;
+
 
         // TODO 2.1
         // Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
         cl_uint devicesCount = 0;
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
+        std::cout << "    Number of devices: " << devicesCount << std::endl;
+
+        std::vector<cl_device_id> devices(devicesCount);
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, devices.data(), nullptr));
 
         for (int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex) {
             // TODO 2.2
@@ -85,6 +95,31 @@ int main() {
             // - Тип устройства (видеокарта/процессор/что-то странное)
             // - Размер памяти устройства в мегабайтах
             // - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+            std::cout << "    Device #" << (deviceIndex + 1) << "/" << devicesCount << std::endl;
+            cl_device_id device = devices[deviceIndex];
+            size_t deviceNameSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, 0, nullptr, &deviceNameSize));
+            std::vector<unsigned char> deviceName(deviceNameSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, deviceNameSize, deviceName.data(), nullptr));
+            std::cout << "    Device name: " << deviceName.data() << std::endl;
+
+            size_t deviceTypeNameSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_TYPE, 0, nullptr, &deviceTypeNameSize));
+            cl_device_type deviceType = CL_DEVICE_TYPE_ALL;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_TYPE, deviceTypeNameSize, &deviceType, nullptr));
+            std::cout << "    Device type: " << deviceType << std::endl;
+
+            size_t deviceMemorySize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE,  0, nullptr, &deviceMemorySize));
+            cl_ulong deviceGlobalMemSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, deviceMemorySize, &deviceGlobalMemSize, nullptr));
+            std::cout << "    Device memory size: " << deviceGlobalMemSize << std::endl;
+
+            size_t deviceVendorSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VENDOR, 0, nullptr, &deviceVendorSize));
+            std::vector<unsigned char> deviceVendor(deviceVendorSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VENDOR, deviceVendorSize, deviceVendor.data(), nullptr));
+            std::cout << "    Vendor: " << deviceVendor.data() << std::endl;
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,11 +115,11 @@ int main() {
             OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, deviceMemorySize, &deviceGlobalMemSize, nullptr));
             std::cout << "    Device memory size: " << deviceGlobalMemSize << std::endl;
 
-            size_t deviceVendorSize = 0;
-            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VENDOR, 0, nullptr, &deviceVendorSize));
-            std::vector<unsigned char> deviceVendor(deviceVendorSize, 0);
-            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VENDOR, deviceVendorSize, deviceVendor.data(), nullptr));
-            std::cout << "    Vendor: " << deviceVendor.data() << std::endl;
+            size_t deviceExtSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, 0, nullptr, &deviceExtSize));
+            std::vector<unsigned char> deviceExt(deviceExtSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, deviceExtSize, deviceExt.data(), nullptr));
+            std::cout << "    Extensions: " << deviceExt.data() << std::endl;
         }
     }
 


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./enumDevices
Number of OpenCL platforms: 2
Platform #1/2
    Platform name: NVIDIA CUDA
    Vendor: NVIDIA Corporation
    Number of devices: 1
    Device #1/1
    Device name: NVIDIA GeForce GTX 1650
    Device type: 4
    Device memory size: 4294508544
    Extensions: cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl
_khr_local_int32_extended_atomics cl_khr_fp64 cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_icd cl_khr_gl_
sharing cl_nv_compiler_options cl_nv_device_attribute_query cl_nv_pragma_unroll cl_nv_d3d10_sharing cl_khr_d3d10_sharing
 cl_nv_d3d11_sharing cl_nv_copy_opts cl_nv_create_buffer cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_
device_uuid cl_khr_pci_bus_info cl_khr_external_semaphore cl_khr_external_memory cl_khr_external_semaphore_win32 cl_khr_
external_memory_win32
Platform #2/2
    Platform name: Intel(R) CPU Runtime for OpenCL(TM) Applications
    Vendor: Intel(R) Corporation
    Number of devices: 1
    Device #1/1
    Device name: AMD Ryzen 3 3200G with Radeon Vega Graphics
    Device type: 2
    Device memory size: 17107472384
    Extensions: cl_khr_icd cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base
_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_3d_image_writes cl
_intel_exec_by_local_thread cl_khr_spir cl_khr_dx9_media_sharing cl_intel_dx9_media_sharing cl_khr_d3d11_sharing cl_khr_
gl_sharing cl_khr_fp64 cl_khr_image2d_from_buffer cl_intel_vec_len_hint
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./enumDevices
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) CPU Runtime for OpenCL(TM) Applications
    Vendor: Intel(R) Corporation
    Number of devices: 1
    Device #1/1
    Device name: AMD EPYC 7763 64-Core Processor                
    Device type: 2
    Device memory size: 16768331776
    Extensions: cl_khr_icd cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_3d_image_writes cl_intel_exec_by_local_thread cl_khr_spir cl_khr_fp64 cl_khr_image2d_from_buffer cl_intel_vec_len_hint
</pre>

</p></details>