### PR TITLE
Task03 Леонид Тернопол SPbU 

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,58 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results,
+                         unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters, int smoothing)
 {
-    // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
+    // если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    int i = get_global_id(0),
+        j = get_global_id(1);
+
+    if (i >= width || j >= height) return;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float result = 0.0;
+
+#ifdef ANTI_ALIASING_ENABLED
+    const unsigned int N = 4;
+    for (int offX = 0; offX <= N; ++offX) {
+        float x0 = fromX + (i + (float)offX / N) * sizeX / width;
+        for (int offY = 0; offY <= N; ++offY) {
+            float y0 = fromY + (j + (float)offY / N) * sizeY / height;
+#else
+    const unsigned int N = 0;
+    {
+        float x0 = fromX + (i + 0.5) * sizeX / width;
+        {
+            float y0 = fromY + (j + 0.5) * sizeY / height;
+#endif
+            float x = x0;
+            float y = y0;
+
+            int iter = 0;
+            for (; iter < iters; ++iter) {
+                float xPrev = x;
+                x = x * x - y * y + x0;
+                y = 2.0f * xPrev * y + y0;
+                if ((x * x + y * y) > threshold2) {
+                    break;
+                }
+            }
+            float res = iter;
+            if (smoothing && iter != iters) {
+                res = res - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+            }
+            result += res;
+        }
+    }
+    result /= (N + 1) * (N + 1) * iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,98 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void sum(__global const unsigned int *as, unsigned int n, __global unsigned int *s)
+{
+#ifdef VARIANT0
+    const unsigned int index = get_global_id(0);
+
+    if (index >= n) return;
+
+    atomic_add(s, as[index]);
+#endif
+
+#ifdef VARIANT1
+    const unsigned int index = get_global_id(0);
+
+    unsigned int sum = 0;
+    for (int idx = index * WORK_PER_ITEM; idx < (index + 1) * WORK_PER_ITEM; ++idx) {
+        if (idx >= n) break;
+        sum += as[idx];
+    }
+    atomic_add(s, sum);
+#endif
+
+#ifdef VARIANT2
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int sum = 0;
+    for (int idx = gid * grs * WORK_PER_ITEM + lid; idx < (gid + 1) * grs * WORK_PER_ITEM; idx += grs) {
+        if (idx >= n) break;
+        sum += as[idx];
+    }
+    atomic_add(s, sum);
+#endif
+
+#ifdef VARIANT3
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? as[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (lid != 0) return;
+
+    unsigned int sum = 0;
+    for (int idx = 0; idx < WORKGROUP_SIZE; ++idx) {
+        sum += buf[idx];
+    }
+    atomic_add(s, sum);
+#endif
+}
+
+__kernel void tree_sum(__global const unsigned int *in, unsigned int n, __global unsigned int *out)
+{
+    const unsigned int gid = get_global_id(0);
+
+    const unsigned int idxOut = gid;
+    const unsigned int stride = (n + 1) / 2;
+
+    if (gid * 2 >= n) return;
+    if (gid * 2 + 1 >= n) {
+        out[idxOut] = in[gid];
+    } else {
+        out[idxOut] = in[gid] + in[gid + stride];
+    }
+}
+
+__kernel void tree_sum2(__global const unsigned int *in, unsigned int n, __global unsigned int *out)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_group_id(0);
+    const unsigned int wid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE * 2];
+    __local unsigned int *buf1 = buf, *buf2 = buf + WORKGROUP_SIZE;
+
+    buf1[lid] = wid < n ? in[wid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int stride = WORKGROUP_SIZE / 2; stride > 0; stride /= 2) {
+        if (lid < stride) {
+            buf2[lid] = buf1[lid] + buf1[lid + stride];
+        }
+        __local unsigned int *tmp = buf1; buf1 = buf2; buf2 = tmp;
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        out[gid] = buf1[0];
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,45 +106,77 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+//        std::string defines = "-D ANTI_ALIASING_ENABLED";
+        std::string defines = "";
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot", defines);
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f img;
+        img.resizeN(width * height);
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height),
+                        img,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit,
+                        1);
+            img.readN(gpu_results.ptr(), width * height);
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "OpenCL: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "OpenCL: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
+//    bool useGPU = true;
 //    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
@@ -165,7 +197,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
     images::Image<float> results(width, height, 1);
     images::Image<unsigned char> image(width, height, 3);
 
-    ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+    ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot", "-D ANTI_ALIASING_ENABLED");
     gpu::gpu_mem_32f results_vram;
     if (useGPU) {
         kernel.compile();

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,7 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/sum_cl.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -14,9 +17,15 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+constexpr bool BUILD_LOG = false;
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
@@ -38,8 +47,8 @@ int main(int argc, char **argv)
             EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
             t.nextLap();
         }
-        std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:                  " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "CPU:                  " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
@@ -53,12 +62,124 @@ int main(int argc, char **argv)
             EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
             t.nextLap();
         }
-        std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP:              " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "CPU OMP:              " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        // implement on OpenCL
+        gpu::gpu_mem_32u as_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), as.size());
+        gpu::gpu_mem_32u sum_gpu;
+        sum_gpu.resizeN(1);
+
+        constexpr int N_VARIANTS = 4;
+        constexpr int WORK_PER_ITEM = 64;
+        constexpr int WORKGROUP_SIZE = 128;
+
+        for (int variant = 0; variant < N_VARIANTS; ++variant) {
+
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum",
+                               "-D WORKGROUP_SIZE=" + std::to_string(WORKGROUP_SIZE) +
+                               " -D WORK_PER_ITEM=" + std::to_string(WORK_PER_ITEM) +
+                               " -D VARIANT" + std::to_string(variant));
+            kernel.compile(BUILD_LOG);
+            unsigned int localN = (variant == 1 || variant == 2) ? n / WORK_PER_ITEM : n;
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                sum_gpu.writeN(&sum, 1);
+
+                kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, localN), as_gpu, n, sum_gpu);
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "OpenCL result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "OpenCL variant " << variant << ":     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "OpenCL variant " << variant << ":     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s"
+                      << std::endl;
+        }
+
+        {
+            gpu::gpu_mem_32u bs_gpu, cs_gpu;
+            bs_gpu.resizeN((n + 1) / 2);
+            cs_gpu.resizeN((n + 1) / 2);
+
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "tree_sum", "-D WORKGROUP_SIZE=" + std::to_string(WORKGROUP_SIZE) +" -D VARIANT0");
+            kernel.compile(BUILD_LOG);
+
+            timer t;
+
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int cur_n = n;
+
+                kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, cur_n), as_gpu, cur_n, bs_gpu);
+                cur_n = (cur_n + 1) / 2;
+
+                while (cur_n > 1) {
+                    kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, cur_n), bs_gpu, cur_n, cs_gpu);
+                    cur_n = (cur_n + 1) / 2;
+                    std::swap(bs_gpu, cs_gpu);
+                }
+
+                unsigned int sum;
+                bs_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "OpenCL result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "OpenCL variant tree:  " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "OpenCL variant tree:  " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s"
+                      << std::endl;
+        }
+
+        {
+            gpu::gpu_mem_32u bs_gpu, cs_gpu;
+            bs_gpu.resizeN((n + 1) / 2);
+            cs_gpu.resizeN((n + 1) / 2);
+
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "tree_sum2", "-D WORKGROUP_SIZE=" + std::to_string(WORKGROUP_SIZE) +" -D VARIANT0");
+            kernel.compile(BUILD_LOG);
+
+            timer t;
+
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int cur_n = n;
+
+                kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, cur_n), as_gpu, cur_n, bs_gpu);
+                cur_n = (cur_n + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE;
+
+                while (cur_n > 1) {
+                    kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, cur_n), bs_gpu, cur_n, cs_gpu);
+                    cur_n = (cur_n + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE;
+                    std::swap(bs_gpu, cs_gpu);
+                }
+
+                unsigned int sum;
+                bs_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "OpenCL result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "OpenCL variant tree2: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "OpenCL variant tree2: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s"
+                      << std::endl;
+        }
     }
+
+    // Анализ вариантов:
+    // 0) Базлайн на GPU работает почти на треть быстрее варианта с векторизацией на CPU (на CPU он очень медленный),
+    //    что, видимо, связанно с оптимизациями atomic_add
+    // 1) Вариант с батчем значений -- лучший на CPU и 2ой в общем зачёте. Не очень понятно, почему OMP не делает так же,
+    //    но тут компилятор прекрасно справляется с компиляцией этого варианта в 512-битные векторные операции.
+    //    С точки зрения CPU, в этом варианте данные уложены оптимально (последовательно), а локальной памяти в CPU нет,
+    //    поэтому этот вариант работает на нём лучше, чем все остальные
+    // 2) Вариант с оптимизаций доступа к данным для GPU закономерно выигрывает,
+    //    конкуренцию ему мог бы составить только вариант с деревом, но, похоже, длина тестового примера слишком маленькая,
+    //    чтобы atomic_add начал проигрывать логарифму перезапусков кернела
+    // 3) Ожидаемо сопоставим с вариантом (1)
+    // tree) На CPU вариант без синхронизации (кроме вызовов кернела) в 2 раза лучше,
+    //       на GPU -- наоборот вариант с большим числом итераций в кернеле в 2 раза быстрее.
+    //       Но они в любом случае проигрывают варианту с батчем и оптимальной укладкой данных.
+    //       Возможно, драйвер сам оптимизирует atomic_add до чего-то похожего на это дерево
+    //       (скорости на (tree2) и (1) на GPU как раз очень похожи)
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./mandelbrot 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 7840HS with Radeon 780M Graphics   . Intel(R) Corporation. Total memory: 28356 Mb
  Device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
Using device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
CPU: 0.2515+-0.00111803 s
CPU: 39.7614 GFlops
    Real iterations fraction: 56.2638%
OpenCL: 0.016+-0.00264575 s
OpenCL: 625 GFlops
    Real iterations fraction: 56.0918%
GPU vs CPU average results difference: 1.09121%

Process finished with exit code 0
</pre>

<pre>
$ ./sum 0
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 7840HS with Radeon 780M Graphics   . Intel(R) Corporation. Total memory: 28356 Mb
  Device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
Using device #0: CPU. AMD Ryzen 7 7840HS with Radeon 780M Graphics   . Intel(R) Corporation. Total memory: 28356 Mb
CPU:                  0.138333+-0.00249444 s
CPU:                  722.892 millions/s
CPU OMP:              0.0221667+-0.000372678 s
CPU OMP:              4511.28 millions/s
OpenCL variant 0:     0.969167+-0.00106719 s
OpenCL variant 0:     103.181 millions/s
OpenCL variant 1:     0.0125+-0.0005 s
OpenCL variant 1:     8000 millions/s
OpenCL variant 2:     0.0145+-0.0005 s
OpenCL variant 2:     6896.55 millions/s
OpenCL variant 3:     0.0126667+-0.000471405 s
OpenCL variant 3:     7894.74 millions/s
OpenCL variant tree:  0.0481667+-0.00186339 s
OpenCL variant tree:  2076.12 millions/s
OpenCL variant tree2: 0.0955+-0.0025 s
OpenCL variant tree2: 1047.12 millions/s

Process finished with exit code 0
</pre>

<pre>
$ ./sum 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 7840HS with Radeon 780M Graphics   . Intel(R) Corporation. Total memory: 28356 Mb
  Device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
Using device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
CPU:                  0.140167+-0.00134371 s
CPU:                  713.436 millions/s
CPU OMP:              0.0223333+-0.000471405 s
CPU OMP:              4477.61 millions/s
OpenCL variant 0:     0.017+-0.00365148 s
OpenCL variant 0:     5882.35 millions/s
OpenCL variant 1:     0.0146667+-0.00314466 s
OpenCL variant 1:     6818.18 millions/s
OpenCL variant 2:     0.0065+-0.0005 s
OpenCL variant 2:     15384.6 millions/s
OpenCL variant 3:     0.0161667+-0.00279384 s
OpenCL variant 3:     6185.57 millions/s
OpenCL variant tree:  0.0258333+-0.00157233 s
OpenCL variant tree:  3870.97 millions/s
OpenCL variant tree2: 0.0143333+-0.00280872 s
OpenCL variant tree2: 6976.74 millions/s

Process finished with exit code 0
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
> Run ./mandelbrot
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.602733+-0.000693887 s
CPU: 16.5911 GFlops
    Real iterations fraction: 56.2638%
OpenCL: 0.169357+-0.000341093 s
OpenCL: 59.047 GFlops
    Real iterations fraction: 56.0918%
GPU vs CPU average results difference: 1.09122%
</pre>

<pre>
> Run ./sum
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 7940 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 7940 Mb
CPU:                  0.0322188+-5.97925e-05 s
CPU:                  3103.77 millions/s
CPU OMP:              0.034555+-9.87775e-05 s
CPU OMP:              2893.94 millions/s
OpenCL variant 0:     0.848753+-0.0683523 s
OpenCL variant 0:     117.82 millions/s
OpenCL variant 1:     0.0441915+-0.00011174 s
OpenCL variant 1:     2262.88 millions/s
OpenCL variant 2:     0.0306125+-0.00010387 s
OpenCL variant 2:     3266.64 millions/s
OpenCL variant 3:     0.075017+-0.000205746 s
OpenCL variant 3:     1333.03 millions/s
OpenCL variant tree:  0.0507613+-0.00058952 s
OpenCL variant tree:  1970 millions/s
OpenCL variant tree2: 0.204112+-0.000576207 s
OpenCL variant tree2: 489.927 millions/s
</pre>

</p></details>
