### PR TITLE
Task03 Василий Можаев SPbU

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,43 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results,
+                        unsigned int width, unsigned int height,
+                        float fromX, float fromY,
+                        float sizeX, float sizeY,
+                        unsigned int iters, int smoothing)
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,100 @@
-// TODO
+__kernel void sum_atomic(
+    __global unsigned int* result, 
+    __global const unsigned int* as, 
+    unsigned int size) 
+{
+    const unsigned int gid = get_global_id(0);
+    if (gid < size) {
+        atomic_add(result, as[gid]);
+    }
+}
+
+#define VALUES_PER_WORKITEM 32
+#define WORKGROUP_SIZE 128
+
+__kernel void sum_for_loop(
+    __global unsigned int* result, 
+    __global const unsigned int* as, 
+    unsigned int size) 
+{
+    const unsigned int gid = get_global_id(0);
+
+    int local_result = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < size) {
+            local_result += as[idx];
+        }
+    }
+    atomic_add(result, local_result);
+}
+
+__kernel void sum_for_loop_coalesced(
+    __global unsigned int* result, 
+    __global const unsigned int* as, 
+    unsigned int size) 
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int grs = get_local_size(0);
+    const unsigned int wid = get_group_id(0);
+
+    int local_result = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < size) {
+            local_result += as[idx];
+        }
+    }
+    atomic_add(result, local_result);
+}
+
+__kernel void sum_local_mem_single_thread(
+    __global unsigned int* result, 
+    __global const unsigned int* as, 
+    unsigned int size) 
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+    const unsigned int grs = get_local_size(0);
+    
+    __local unsigned int buf[WORKGROUP_SIZE];
+    buf[lid] = gid < size ? as[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int local_result = 0;
+        for (int i = 0; i < grs; ++i) {
+            local_result += buf[i];
+        }
+        atomic_add(result, local_result);
+
+    }
+}
+
+__kernel void sum_local_mem_tree(
+    __global unsigned int* result, 
+    __global const unsigned int* as, 
+    unsigned int size) 
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+    const unsigned int grs = get_local_size(0);
+    
+    __local unsigned int buf[WORKGROUP_SIZE];
+    buf[lid] = gid < size ? as[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    unsigned int local_result = 0;
+    for (int jump = 1; jump < WORKGROUP_SIZE; jump *= 2) {
+        int idx = 2 * lid * jump;
+        if (idx < WORKGROUP_SIZE) {
+            buf[idx] += buf[idx + jump];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    
+    if (lid == 0) {
+        atomic_add(result, buf[0]);
+    }
+}
+

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,46 +106,83 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f out_buf;
+        unsigned int size = width * height;
+        out_buf.resizeN(size);
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(
+                gpu::WorkSize(16, 16, width, height), 
+                out_buf, 
+                width, 
+                height,
+                centralX - sizeX / 2.0f, 
+                centralY - sizeY / 2.0f,
+                sizeX, 
+                sizeY,
+                iterationsLimit, 
+                0
+            );
+            out_buf.readN(gpu_results.ptr(), size);
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        // save to file
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // bool useGPU = false;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+
+#include "cl/sum_cl.h"
 
 
 template<typename T>
@@ -14,6 +18,63 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+struct tester {
+    tester(
+        int argc, 
+        char** argv, 
+        std::vector<unsigned int>& as, 
+        int benchmarkingIters, 
+        unsigned int referenceSum, 
+        unsigned int n) 
+            : 
+            as(as), 
+            benchmarkingIters(benchmarkingIters), 
+            referenceSum(referenceSum), 
+            n(n),
+            context()
+    {
+        device = gpu::chooseGPUDevice(argc, argv);
+        context.init(device.device_id_opencl);
+        context.activate();
+        
+        as_buf.resize(sizeof(unsigned int) * n);
+        as_buf.write(as.data(), sizeof(unsigned int) * n);
+
+        result_buf.resize(sizeof(unsigned int));
+    }
+
+    void execute_and_time(std::string kernel_name) {
+        unsigned int zero = 0;
+
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+        kernel.compile();
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sum = 0;
+
+            result_buf.write(&zero, sizeof(unsigned int));
+            kernel.exec(gpu::WorkSize(128, n), result_buf, as_buf, n);
+            result_buf.read(&sum, sizeof(unsigned int));
+            
+            EXPECT_THE_SAME(referenceSum, sum, kernel_name + " result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << kernel_name + ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << kernel_name + ": " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+    
+
+private:
+    const std::vector<unsigned int>& as;
+    const int benchmarkingIters;
+    const unsigned int referenceSum;
+    const unsigned int n;
+    gpu::Device device;
+    gpu::Context context;
+    gpu::gpu_mem_any as_buf;
+    gpu::gpu_mem_any result_buf;
+};
 
 int main(int argc, char **argv)
 {
@@ -59,6 +120,11 @@ int main(int argc, char **argv)
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        tester t(argc, argv, as, benchmarkingIters, reference_sum, n);
+        t.execute_and_time("sum_atomic");
+        t.execute_and_time("sum_for_loop");
+        t.execute_and_time("sum_for_loop_coalesced");
+        t.execute_and_time("sum_local_mem_single_thread");
+        t.execute_and_time("sum_local_mem_tree");
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./mandelbrot 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
  Device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Using device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
CPU: 0.666434+-0.00720109 s
CPU: 15.0052 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0451585+-0.00101486 s
GPU: 221.442 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

<pre>
$ ./sum 1
CPU:     0.241569+-0.00092073 s
CPU:     413.961 millions/s
CPU OMP: 0.0734905+-0.000956604 s
CPU OMP: 1360.72 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
  Device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Using device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
sum_atomic: 0.0164845+-0.000339852 s
sum_atomic: 6066.3 millions/s
sum_for_loop: 0.0700362+-8.3749e-06 s
sum_for_loop: 1427.83 millions/s
sum_for_loop_coalesced: 0.075964+-6.55744e-06 s
sum_for_loop_coalesced: 1316.41 millions/s
sum_local_mem_single_thread: 0.0340063+-2.13437e-06 s
sum_local_mem_single_thread: 2940.63 millions/s
sum_local_mem_tree: 0.053376+-2.88675e-06 s
sum_local_mem_tree: 1873.5 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
./mandelbrot
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.600346+-0.00252644 s
CPU: 16.6571 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.159891+-0.000260552 s
GPU: 62.5425 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.943129%
</pre>

<pre>
./sum
CPU:     0.0322435+-7.36405e-05 s
CPU:     3101.4 millions/s
CPU OMP: 0.021028+-0.00390069 s
CPU OMP: 4755.56 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
sum_atomic: 1.63229+-0.00114072 s
sum_atomic: 61.2638 millions/s
sum_for_loop: 1.9278+-0.00140563 s
sum_for_loop: 51.8727 millions/s
sum_for_loop_coalesced: 1.63934+-0.00217872 s
sum_for_loop_coalesced: 61.0001 millions/s
sum_local_mem_single_thread: 0.02932+-3.32716e-05 s
sum_local_mem_single_thread: 3410.64 millions/s
sum_local_mem_tree: 0.166307+-0.000488576 s
sum_local_mem_tree: 601.296 millions/s
</pre>

</p></details>

Либо я чего-то не понял, либо результаты получились супер странные: 
- самый тупой вариант с `atomic_add` оказался самым быстрым (_6066.3 millions/s_), 
- коалесд доступ к памяти получился медленее не коалесд (_1316.41 millions/s_ VS _1427.83 millions/s_), 
- вариант с локальной памятью и одним потоком (тот где куча атомиков) получился быстрее варианта с деревом (_2940.63 millions/s_ VS _1873.5 millions/s_). 

Вроде подсчет всего этого я скопировал с подсчёта для CPU, так что должно быть правильно... (из-за таких результатов я сначала подумал что здесь наоборот чем больше число, тем хуже)

Ещё я попробовал выбрать CPU в качестве OpenCL устройства, тут первые 3 варианта очень медленные, а варианты с локальной памятью нормальные, при чем вариант с одним потоком и кучей атомиков быстрее варианта с деревом. Кстати результаты почти совпадают с результатами на GitHub CI/CD.
<details><summary>CPU as OpenCL device</summary><p>
<pre>
$ ./mandelbrot 0
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
  Device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Using device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
CPU: 0.664233+-0.00397037 s
CPU: 15.055 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.134783+-0.00836381 s
GPU: 74.1934 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.943129%
</pre>

<pre>
$ ./sum 0
CPU:     0.242326+-0.00737564 s
CPU:     412.668 millions/s
CPU OMP: 0.0749157+-0.00209302 s
CPU OMP: 1334.83 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
  Device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Using device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
sum_atomic: 1.77821+-0.00385719 s
sum_atomic: 56.2365 millions/s
sum_for_loop: 1.94269+-0.00454948 s
sum_for_loop: 51.4751 millions/s
sum_for_loop_coalesced: 2.09413+-0.0253382 s
sum_for_loop_coalesced: 47.7525 millions/s
sum_local_mem_single_thread: 0.0287173+-0.00123197 s
sum_local_mem_single_thread: 3482.22 millions/s
sum_local_mem_tree: 0.152239+-0.00388894 s
sum_local_mem_tree: 656.863 millions/s
</pre>
</p></details>

И ещё насчёт 3.2, показалось немного странным, что пишет, что у меня `GPU: 221.442 GFlops`, хотя в Task01 (там где просто массивы суммировались), было в 100 раз меньше. Я так понял, что это из-за того что тут задача более масштабная, и поэтому получается задействовать больше мощностей.