### PR TITLE
Task03 Дениль Шарипов СПбГУ

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,62 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+float recalc_point(float x0, float y0, unsigned int iters, const float threshold, const float threshold2, int smoothing) {
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+
+    return result;
+}
+
+__kernel void mandelbrot(
+    __global float* results,
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, int smoothing,
+    unsigned int antialiasingLevel
+)
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (i >= width || j >= height) {
+        return;
+    }
+
+    float result = 0;
+    for (int ii = 0; ii <= antialiasingLevel; ++ii) {
+        for (int jj = 0; jj <= antialiasingLevel; ++jj) {
+            float x0 = fromX + (i + (1.0f * (ii + 1) / (antialiasingLevel + 2))) * sizeX / width;
+            float y0 = fromY + (j + (1.0f * (jj + 1) / (antialiasingLevel + 2))) * sizeY / height;
+            result += recalc_point(x0, y0, iters, threshold, threshold2, smoothing);
+        }
+    }
+
+    result /= (antialiasingLevel + 1) * (antialiasingLevel + 1);
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -4,8 +4,8 @@
 
 #line 6
 
-#define VALUES_PER_WORKITEM 32
-#define WORKGROUP_SIZE 128
+#define VALUES_PER_WORKITEM 16
+#define WORKGROUP_SIZE 256
 
 __kernel void sum_gpu_1(__global const unsigned int* arr,
                         __global unsigned int* sum,

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,105 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define VALUES_PER_WORKITEM 32
+#define WORKGROUP_SIZE 128
+
+__kernel void sum_gpu_1(__global const unsigned int* arr,
+                        __global unsigned int* sum,
+                        unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n)
+        return;
+
+    atomic_add(sum, arr[gid]);
+}
+
+__kernel void sum_gpu_2(__global const unsigned int* arr,
+                        __global unsigned int* sum,
+                        unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        unsigned int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+__kernel void sum_gpu_3(__global const unsigned int* arr,
+                        __global unsigned int* sum,
+                        unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        unsigned int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+__kernel void sum_gpu_4(__global const unsigned int* arr,
+                        __global unsigned int* sum,
+                        unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? arr[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; i++) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+__kernel void sum_gpu_5(__global const unsigned int* arr,
+                        __global unsigned int* sum,
+                        unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? arr[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues / 2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -25,12 +25,14 @@ __kernel void sum_gpu_2(__global const unsigned int* arr,
 {
     const unsigned int gid = get_global_id(0);
 
+    if (gid * VALUES_PER_WORKITEM >= n) {
+        return;
+    }
+
     unsigned int res = 0;
     for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
         unsigned int idx = gid * VALUES_PER_WORKITEM + i;
-        if (idx < n) {
-            res += arr[idx];
-        }
+        res += arr[idx];
     }
 
     atomic_add(sum, res);
@@ -44,12 +46,14 @@ __kernel void sum_gpu_3(__global const unsigned int* arr,
     const unsigned int wid = get_group_id(0);
     const unsigned int grs = get_local_size(0);
 
+    if (wid * grs * VALUES_PER_WORKITEM >= n) {
+        return;
+    }
+
     unsigned int res = 0;
     for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
         unsigned int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
-        if (idx < n) {
-            res += arr[idx];
-        }
+        res += arr[idx];
     }
 
     atomic_add(sum, res);

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
 
     float sizeY = sizeX * height / width;
 
-    {
+    {   
         timer t;
         for (int i = 0; i < benchmarkingIters; ++i) {
             mandelbrotCPU(cpu_results.ptr(),
@@ -106,48 +106,79 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+   // Раскомментируйте это:
 
-    // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
-    // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
+   gpu::Context context;
+   context.init(device.device_id_opencl);
+   context.activate();
+   {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = true;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f results;
+        results.resizeN(width * height);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height),
+                        results,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit, 0,
+                        0);
+            results.readN(gpu_results.ptr(), width * height);
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(cpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+   {
+       double errorAvg = 0.0;
+       for (int j = 0; j < height; ++j) {
+           for (int i = 0; i < width; ++i) {
+               errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+           }
+       }
+       errorAvg /= width * height;
+       std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+       if (errorAvg > 0.03) {
+           throw std::runtime_error("Too high difference between CPU and GPU results!");
+       }
+   }
+
+//     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
+//     // Кликами мышки можно смещать ракурс
+//     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
 //    bool useGPU = false;
 //    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
-    return 0;
+   return 0;
 }
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
@@ -183,7 +214,8 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
                         results_vram, width, height,
                         centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
                         sizeX, sizeY,
-                        iterationsLimit, 1);
+                        iterationsLimit, 1,
+                        1);
             results_vram.readN(results.ptr(), width * height);
         }
         renderToColor(results.ptr(), image.ptr(), width, height);

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,7 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/sum_cl.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -14,13 +17,42 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+void run(const std::vector<unsigned int>& as, unsigned int referenceSum, int benchmarkingIters, gpu::Device device, ocl::Kernel kernel, std::string kernelName) {
+    unsigned int n = as.size();
+    unsigned int workGroupSize = 128;
+    unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+    gpu::gpu_mem_32u as_gpu;
+    as_gpu.resizeN(n);
+    as_gpu.writeN(as.data(), n);
+
+    kernel.compile(false);
+    {
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sum = 0;
+
+            gpu::gpu_mem_32u sum_gpu;
+            sum_gpu.resizeN(1);
+            sum_gpu.writeN(&sum, 1);
+            kernel.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, sum_gpu, n);
+            sum_gpu.readN(&sum, 1);
+
+            EXPECT_THE_SAME(referenceSum, sum, "GPU " + kernelName + " result should be consistent!");
+
+            t.nextLap();
+        }
+        std::cout << "GPU " + kernelName + ":     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU " + kernelName + ":     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+}
 
 int main(int argc, char **argv)
 {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -59,6 +91,24 @@ int main(int argc, char **argv)
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
-    }
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        ocl::Kernel globalAtomic(sum_kernel, sum_kernel_length, "sum_gpu_1");
+        run(as, reference_sum, benchmarkingIters, device, globalAtomic, "globalAtomic");
+
+        ocl::Kernel loopSum(sum_kernel, sum_kernel_length, "sum_gpu_2");
+        run(as, reference_sum, benchmarkingIters, device, loopSum, "loopSum");
+
+        ocl::Kernel loopSumCoalesced(sum_kernel, sum_kernel_length, "sum_gpu_3");
+        run(as, reference_sum, benchmarkingIters, device, loopSumCoalesced, "loopSumCoalesced");
+
+        ocl::Kernel localMemorySum(sum_kernel, sum_kernel_length, "sum_gpu_4");
+        run(as, reference_sum, benchmarkingIters, device, localMemorySum, "localMemorySum");
+
+        ocl::Kernel treeSum(sum_kernel, sum_kernel_length, "sum_gpu_5");
+        run(as, reference_sum, benchmarkingIters, device, treeSum, "treeSum");
+    }   
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -17,9 +17,8 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
-void run(const std::vector<unsigned int>& as, unsigned int referenceSum, int benchmarkingIters, gpu::Device device, ocl::Kernel kernel, std::string kernelName) {
+void run(const std::vector<unsigned int>& as, unsigned int referenceSum, int benchmarkingIters, gpu::Device device, ocl::Kernel kernel, std::string kernelName, int workGroupSize) {
     unsigned int n = as.size();
-    unsigned int workGroupSize = 128;
     unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
 
     gpu::gpu_mem_32u as_gpu;
@@ -97,18 +96,18 @@ int main(int argc, char **argv)
         context.activate();
 
         ocl::Kernel globalAtomic(sum_kernel, sum_kernel_length, "sum_gpu_1");
-        run(as, reference_sum, benchmarkingIters, device, globalAtomic, "globalAtomic");
+        run(as, reference_sum, benchmarkingIters, device, globalAtomic, "globalAtomic", 256);
 
         ocl::Kernel loopSum(sum_kernel, sum_kernel_length, "sum_gpu_2");
-        run(as, reference_sum, benchmarkingIters, device, loopSum, "loopSum");
+        run(as, reference_sum, benchmarkingIters, device, loopSum, "loopSum", 32);
 
         ocl::Kernel loopSumCoalesced(sum_kernel, sum_kernel_length, "sum_gpu_3");
-        run(as, reference_sum, benchmarkingIters, device, loopSumCoalesced, "loopSumCoalesced");
+        run(as, reference_sum, benchmarkingIters, device, loopSumCoalesced, "loopSumCoalesced", 32);
 
         ocl::Kernel localMemorySum(sum_kernel, sum_kernel_length, "sum_gpu_4");
-        run(as, reference_sum, benchmarkingIters, device, localMemorySum, "localMemorySum");
+        run(as, reference_sum, benchmarkingIters, device, localMemorySum, "localMemorySum", 256);
 
         ocl::Kernel treeSum(sum_kernel, sum_kernel_length, "sum_gpu_5");
-        run(as, reference_sum, benchmarkingIters, device, treeSum, "treeSum");
+        run(as, reference_sum, benchmarkingIters, device, treeSum, "treeSum", 256);
     }   
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

Мандельброт:
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
CPU: 0.18568+-0.00268642 s
CPU: 53.856 GFlops
    Real iterations fraction: 56.2638%
Building kernels for Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz... 
Kernels compilation done in 0.070677 seconds
Device 1
        Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (8)
Done.

GPU: 0.037295+-0.000234195 s
GPU: 268.132 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

Сумма:
<pre>
CPU:     0.395483+-0.00536006 s
CPU:     252.856 millions/s
CPU OMP: 0.0266963+-0.00108514 s
CPU OMP: 3745.83 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
GPU globalAtomic:     2.03276+-0.0449705 s
GPU globalAtomic:     49.1942 millions/s
GPU loopSum:     2.71588+-0.0544442 s
GPU loopSum:     36.8205 millions/s
GPU loopSumCoalesced:     2.35757+-0.0406448 s
GPU loopSumCoalesced:     42.4166 millions/s
GPU localMemorySum:     0.0362958+-0.0020097 s
GPU localMemorySum:     2755.14 millions/s
GPU treeSum:     0.0418552+-0.0030216 s
GPU treeSum:     2389.19 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>

Мандельброт:
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.599399+-0.00193229 s
CPU: 16.6834 GFlops
    Real iterations fraction: 56.2638%
Building kernels for AMD EPYC 7763 64-Core Processor                ... 
Kernels compilation done in 0.0428 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (8)
Done.

GPU: 0.159685+-0.00086159 s
GPU: 62.6232 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

Сумма:
<pre>
CPU:     0.0321713+-6.9004e-05 s
CPU:     3108.36 millions/s
CPU OMP: 0.0176093+-0.00016401 s
CPU OMP: 5678.81 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU globalAtomic:     1.431+-0.0349563 s
GPU globalAtomic:     69.8812 millions/s
GPU loopSum:     1.72111+-0.035651 s
GPU loopSum:     58.1022 millions/s
GPU loopSumCoalesced:     1.47388+-0.0418458 s
GPU loopSumCoalesced:     67.8479 millions/s
GPU localMemorySum:     0.0399112+-0.000189029 s
GPU localMemorySum:     2505.56 millions/s
GPU treeSum:     0.162477+-0.000545237 s
GPU treeSum:     615.47 millions/s
</pre>

</p></details>

Проанализируем, почему у суммы получились именно такие результаты. Кернелы запускал на 64-х ядерном CPU Intel(R) Xeon(R), соответственно параллелизм происходил за счет SIMD (то есть использование векторных интринсиков). Для начала сразу бросается в глаза, что версия с OMP самая быстрая. Это логично, поскольку задача редукции прекрасно решается в параллельной модели, стоит ожидать, что OMP использует хорошо оптимизированный алгоритм для этой задачи. Кернелы globalAtomic, loopSum, loopSumCoalesced проигрывают довольно сильно даже обычной CPU версии, при этом все три кернела имеют сравнимый перфоманс. Можно предположить, что это происходит из-за аккумуляторного способа вычисления суммы и оверхеда из-за синхронизации между потоками. Кернелы  localMemorySum и treeSum сильно быстрее предыдущих, а так же наивной CPU версии, вероятно из-за использования стековой памяти (локальный буффер), доступ к которой более быстрый, чем к куче, при этом localMemorySum показывает больший перфоманс, чем treeSum (причем разница будет увеличиваться по мере увеличения размеры воркгруппы). Последнее не ожидаемо, возможно это происходит из-за каких-то оптимизаций компилятора.