### PR TITLE
Task03 Роман Гостило HSE

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -1,11 +1,49 @@
 #ifdef __CLION_IDE__
+
 #include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(
+        __global float *results,
+        unsigned int width, unsigned int height,
+        float fromX, float fromY,
+        float sizeX, float sizeY,
+        unsigned int iters, int is_smoothing) {
+    const unsigned int index = get_global_id(0);
+    const unsigned int index_x = index % width;
+    const unsigned int index_y = index / width;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (index_x + 0.5f) * sizeX / width;
+    float y0 = fromY + (index_y + 0.5f) * sizeY / height;
+
+
+    float x = x0;
+    float y = y0;
+
+    unsigned int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = iter;
+    if (is_smoothing && iter != iters)     {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[index_y * width + index_x] = result;
+
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,38 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#line 6
+
+__kernel void sum_atomic(
+        __global const unsigned int *arr,
+        __global unsigned int *sum,
+        unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n) {
+        return;
+    };
+
+    atomic_add(sum, arr[gid]);
+}
+
+#define VALUES_PER_WORKITEM 64
+__kernel void sum_cycle(
+        __global const unsigned int *arr,
+        __global unsigned int *sum,
+        unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        unsigned int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -56,7 +56,7 @@ __kernel void sum_cycle_coalesced(
     atomic_add(sum, res);
 }
 
-#define WORKGROUP_SIZE 32
+#define WORKGROUP_SIZE 128
 __kernel void sum_one_main_thread(
         __global const unsigned int *arr,
         __global unsigned int *sum,
@@ -68,6 +68,8 @@ __kernel void sum_one_main_thread(
 
     buf[local_id] = gid < n ? arr[gid] : 0;
 
+    barrier(CLK_LOCAL_MEM_FENCE);
+
     if (local_id == 0) {
         unsigned int group_res = 0;
         for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
@@ -77,7 +79,7 @@ __kernel void sum_one_main_thread(
     }
 }
 
-#define WORKGROUP_SIZE 32
+#define WORKGROUP_SIZE 128
 __kernel void sum_tree(
         __global const unsigned int *arr,
         __global unsigned int *sum,

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -28,7 +28,7 @@ __kernel void sum_cycle(
 
     unsigned int res = 0;
     for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
-        unsigned int idx = gid * VALUES_PER_WORKITEM + i;
+        unsigned long long idx = gid * VALUES_PER_WORKITEM + i;
         if (idx < n) {
             res += arr[idx];
         }
@@ -36,3 +36,78 @@ __kernel void sum_cycle(
 
     atomic_add(sum, res);
 }
+
+#define VALUES_PER_WORKITEM 64
+__kernel void sum_cycle_coalesced(
+        __global const unsigned int *arr,
+        __global unsigned int *sum,
+        unsigned int n) {
+    const unsigned int local_id = get_local_id(0);
+    const unsigned int work_group_id = get_group_id(0);
+    const unsigned int group_size = get_local_size(0);
+    int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = work_group_id * group_size * VALUES_PER_WORKITEM + i * group_size + local_id;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+#define WORKGROUP_SIZE 128
+__kernel void sum_one_main_thread(
+        __global const unsigned int *arr,
+        __global unsigned int *sum,
+        unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int local_id = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[local_id] = arr[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_id == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
+            if (gid + i < n) {
+                group_res += buf[i];
+            }
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+#define WORKGROUP_SIZE 128
+__kernel void sum_tree(
+        __global const unsigned int *arr,
+        __global unsigned int *sum,
+        unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int local_id = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[local_id] = gid < n ? arr[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (unsigned int values_count = WORKGROUP_SIZE; values_count > 1; values_count /= 2) {
+        if (local_id * 2 < values_count) {
+            int a = buf[local_id];
+            int b = buf[local_id + values_count / 2];
+            buf[local_id] = a + b;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (local_id == 0) {
+        atomic_add(sum, buf[0]);
+    }
+
+}
+

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -56,7 +56,7 @@ __kernel void sum_cycle_coalesced(
     atomic_add(sum, res);
 }
 
-#define WORKGROUP_SIZE 128
+#define WORKGROUP_SIZE 32
 __kernel void sum_one_main_thread(
         __global const unsigned int *arr,
         __global unsigned int *sum,
@@ -66,22 +66,18 @@ __kernel void sum_one_main_thread(
 
     __local unsigned int buf[WORKGROUP_SIZE];
 
-    buf[local_id] = arr[gid];
-
-    barrier(CLK_LOCAL_MEM_FENCE);
+    buf[local_id] = gid < n ? arr[gid] : 0;
 
     if (local_id == 0) {
         unsigned int group_res = 0;
         for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
-            if (gid + i < n) {
-                group_res += buf[i];
-            }
+            group_res += buf[i];
         }
         atomic_add(sum, group_res);
     }
 }
 
-#define WORKGROUP_SIZE 128
+#define WORKGROUP_SIZE 32
 __kernel void sum_tree(
         __global const unsigned int *arr,
         __global unsigned int *sum,

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -160,6 +160,8 @@ int main(int argc, char **argv)
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
+        gpu_results_buf.readN(gpu_results.ptr(), n);
+
         double realIterationsFraction = 0.0;
         for (int j = 0; j < height; ++j) {
             for (int i = 0; i < width; ++i) {
@@ -168,7 +170,6 @@ int main(int argc, char **argv)
         }
         std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
 
-        gpu_results_buf.readN(gpu_results.ptr(), n);
         renderToColor(gpu_results.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_gpu.png");
     }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -117,9 +117,9 @@ int main(int argc, char **argv) {
     auto kernel_runner = GPUKernelRunner(as, benchmarkingIters);
     {
         kernel_runner.run("sum_atomic", gpu::WorkSize(128, n));
-        kernel_runner.run("sum_cycle", gpu::WorkSize(128, n / 64));
+        kernel_runner.run("sum_cycle", gpu::WorkSize(32, n / 64));
         kernel_runner.run("sum_cycle_coalesced", gpu::WorkSize(128, n / 64));
-        kernel_runner.run("sum_one_main_thread", gpu::WorkSize(128, n));
-        kernel_runner.run("sum_tree", gpu::WorkSize(128, n));
+        kernel_runner.run("sum_one_main_thread", gpu::WorkSize(32, n));
+        kernel_runner.run("sum_tree", gpu::WorkSize(32, n));
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -117,9 +117,9 @@ int main(int argc, char **argv) {
     auto kernel_runner = GPUKernelRunner(as, benchmarkingIters);
     {
         kernel_runner.run("sum_atomic", gpu::WorkSize(128, n));
-        kernel_runner.run("sum_cycle", gpu::WorkSize(32, n / 64));
+        kernel_runner.run("sum_cycle", gpu::WorkSize(128, n / 64));
         kernel_runner.run("sum_cycle_coalesced", gpu::WorkSize(128, n / 64));
-        kernel_runner.run("sum_one_main_thread", gpu::WorkSize(32, n));
-        kernel_runner.run("sum_tree", gpu::WorkSize(32, n));
+        kernel_runner.run("sum_one_main_thread", gpu::WorkSize(128, n));
+        kernel_runner.run("sum_tree", gpu::WorkSize(128, n));
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,14 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <numeric>
+#include "libgpu/context.h"
 
+#include "cl/sum_cl.h"
+#include "libgpu/shared_device_buffer.h"
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -14,13 +17,64 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+class GPUKernelRunner {
+public:
+    GPUKernelRunner(const std::vector<unsigned int> &t_arr, const int t_benchmarking_iters) : arr(t_arr),
+                                                                                              benchmarking_iters(
+                                                                                                      t_benchmarking_iters) {
+        n = t_arr.size();
+        reference_sum = 0;
+        std::for_each(t_arr.begin(), t_arr.end(), [&](int elem) {
+            reference_sum += elem;
+        });
+    }
 
-int main(int argc, char **argv)
-{
+    void run(const std::string &kernel_name) {
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+        bool printLog = false;
+        kernel.compile(printLog);
+
+        gpu::gpu_mem_32u arr_gpu;
+        gpu::gpu_mem_32u sum_gpu;
+        arr_gpu.resizeN(n);
+        sum_gpu.resizeN(1);
+
+        arr_gpu.writeN(arr.data(), n);
+
+        unsigned int workGroupSize = 128;
+
+        timer t;
+
+        for (int i = 0; i < benchmarking_iters; ++i) {
+            unsigned int sum = 0;
+            sum_gpu.writeN(&sum, 1);
+            kernel.exec(gpu::WorkSize(workGroupSize, n),
+                        arr_gpu,
+                        sum_gpu,
+                        n);
+            sum_gpu.readN(&sum, 1);
+            EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
+            t.nextLap();
+        }
+
+        std::cout << "GPU " + kernel_name + ":     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU " + kernel_name + ":     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s"
+                  << std::endl;
+    }
+
+private:
+    unsigned int n;
+    int benchmarking_iters = 10;
+    unsigned int reference_sum = 0;
+    std::vector<unsigned int> arr;
+};
+
+
+int main(int argc, char **argv) {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -39,14 +93,14 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+:sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
@@ -54,11 +108,17 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
+    gpu::Context context;
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    auto kernel_runner = GPUKernelRunner(as, benchmarkingIters);
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        kernel_runner.run("sum_cycle");
+//        kernel_runner.run("sum_atomic");
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
<pre>
// mandelbrot
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
CPU: 2.15487+-0.00394714 s
CPU: 4.64065 GFlops
    Real iterations fraction: 40.7078%
GPU: 0.0020275+-0.000307922 s
GPU: 4932.18 GFlops
    Real iterations fraction: 40.7078%
GPU vs CPU average results difference: 0%

// sum
CPU:     0.135931+-0.000978535 s
CPU:     735.667 millions/s
CPU OMP: 0.137111+-0.00219262 s
CPU OMP: 729.336 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU sum_atomic:     0.00476217+-0.000733758 s
GPU sum_atomic:     20998.8 millions/s
GPU sum_cycle:     0.00304367+-0.000685762 s
GPU sum_cycle:     32855.1 millions/s
GPU sum_cycle_coalesced:     0.00194767+-0.000212206 s
GPU sum_cycle_coalesced:     51343.5 millions/s
GPU sum_one_main_thread:     0.00713083+-3.86541e-05 s
GPU sum_one_main_thread:     14023.6 millions/s
GPU sum_tree:     0.00805767+-0.000223619 s
GPU sum_tree:     12410.5 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
// mandelbrot
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.561961+-0.00475791 s
CPU: 17.7948 GFlops
    Real iterations fraction: 40.7076%
GPU: 0.108266+-2.0672e-05 s
GPU: 92.3651 GFlops
    Real iterations fraction: 40.7078%
GPU vs CPU average results difference: 0.019951%

// sum 
CPU:     0.0322773+-0.000117328 s
CPU:     3098.15 millions/s
CPU OMP: 0.0174108+-0.000120569 s
CPU OMP: 5743.55 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU sum_atomic:     1.50988+-0.00112108 s
GPU sum_atomic:     66.2305 millions/s
GPU sum_cycle:     0.0281685+-2.42401e-05 s
GPU sum_cycle:     3550.06 millions/s
GPU sum_cycle_coalesced:     0.0253547+-1.33998e-05 s
GPU sum_cycle_coalesced:     3944.05 millions/s
GPU sum_one_main_thread:     0.0379563+-4.67856e-05 s
GPU sum_one_main_thread:     2634.61 millions/s
GPU sum_tree:     0.174933+-0.000647368 s
GPU sum_tree:     571.649 millions/s
</pre>

</p></details>

coalesced ожидаемо быстрее, чем не coalesced. Удивительно, что локально бейзлайн с atomic_add оказался быстрее, чем дерево или решение с main_thread. Вероятно, процессор как-то это хитро заоптимизировал с локальной памятью.
Мои находки будут касаться архитектуры Apple Silicon. Нормальных материалов про архитектуру GPU-ядер нет, поэтому я решил разобраться опытным путем.
Обнаружил, что размер execution unit (warp) у Apple - всего лишь 8 потоков! Если уменьшать work_group_size до 8, это никак не влияет производительность в первых трёх кёрнелах. В последних двух производительность падает, но по понятным причинам: в sum_main_thread резко растет количество atomic_add, а в sum_tree страдает глубина дерева.
Также выяснил, что в отличие от других процессоров, размер кэш-линии на Apple Silicon - 128 байт, прямо как на видеокартах. Если выставить в for_loop_coalesced размер группы 64, то производительность существенно падает - почти сравнивается с for_loop не coalesced.
