### PR TITLE
Task03 Дмитрий Артюхов HSE

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,48 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(
+     __global float* results,
+    unsigned int width,
+    unsigned int height,
+    float fromX,
+    float fromY,
+    float sizeX,
+    float sizeY,
+    unsigned int iters,
+    unsigned int smoothing
+) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const unsigned int idx = get_global_id(0);
+    const unsigned int i = idx % width;
+    const unsigned int j = idx / width;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,119 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void sum_gpu_global_atomic(
+    __global const unsigned int* as,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    if (gid >= n) return;
+
+    atomic_add(sum, as[gid]);
+}
+
+__kernel void sum_gpu_cycle(
+    __global const unsigned int* as,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int VALUES_PER_WORKITEM = 64;
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        unsigned long long idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += as[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+
+__kernel void sum_gpu_coalesed_cycle(
+    __global const unsigned int* as,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    const unsigned int VALUES_PER_WORKITEM = 64;
+
+    unsigned int res = 0;
+    for (unsigned int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        unsigned int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += as[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+
+
+__kernel void sum_gpu_local(
+    __global const unsigned int* as,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    const unsigned int WORKGROUP_SIZE = 128;
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = as[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; i++) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+
+
+__kernel void sum_gpu_tree(
+    __global const unsigned int* as,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+
+    const unsigned int WORKGROUP_SIZE = 128;
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? as[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues / 2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}
+

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,46 +106,89 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = true;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+
+        unsigned int n = width * height;
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+        gpu::gpu_mem_32f gpu_result_buf;
+        gpu_result_buf.resizeN(n);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(
+                gpu::WorkSize(workGroupSize, global_work_size),
+                gpu_result_buf,
+                width,
+                height,
+                centralX - sizeX / 2.0f,
+                centralY - sizeY / 2.0f,
+                sizeX,
+                sizeY,
+                iterationsLimit,
+                0U
+            );
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        gpu_result_buf.readN(gpu_results.ptr(), n);
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    bool useGPU = true;
+    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -187,8 +187,8 @@ int main(int argc, char **argv)
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-    bool useGPU = true;
-    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+//     bool useGPU = true;
+//     renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,7 +1,12 @@
+#include "libgpu/shared_device_buffer.h"
+
+
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
+#include "cl/sum_cl.h"
+#include "libgpu/context.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -15,50 +20,126 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
+
+
+void runGpuKernel(
+    int benchmarkingIters,
+    const std::string& kernel_name,
+    const gpu::WorkSize& work_size,
+    gpu::gpu_mem_32u& as_gpu,
+    gpu::gpu_mem_32u& sum_gpu,
+    unsigned int n,
+    unsigned int reference_sum,
+    bool printLog = false
+) {
+    ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+    kernel.compile(printLog);
+
+    timer t;
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        unsigned int sum = 0;
+        sum_gpu.writeN(&sum, 1);
+
+        kernel.exec(
+            work_size,
+            as_gpu,
+            sum_gpu,
+            n
+        );
+
+        sum_gpu.readN(&sum, 1);
+        EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+        t.nextLap();
+    }
+    std::cout << "GPU <" << kernel_name << ">: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU <" << kernel_name << ">: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+    std::cout << std::endl;
+}
+
 int main(int argc, char **argv)
 {
-    int benchmarkingIters = 10;
+    try {
+        int benchmarkingIters = 10;
 
-    unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
-    std::vector<unsigned int> as(n, 0);
-    FastRandom r(42);
-    for (int i = 0; i < n; ++i) {
-        as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
-        reference_sum += as[i];
-    }
-
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            unsigned int sum = 0;
-            for (int i = 0; i < n; ++i) {
-                sum += as[i];
-            }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
-            t.nextLap();
+        unsigned int reference_sum = 0;
+        unsigned int n = 100*1000*1000;
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(42);
+        for (int i = 0; i < n; ++i) {
+            as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
+            reference_sum += as[i];
         }
-        std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
-    }
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
-            for (int i = 0; i < n; ++i) {
-                sum += as[i];
+        // Pure CPU
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                for (int i = 0; i < n; ++i) {
+                    sum += as[i];
+                }
+                EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
+                t.nextLap();
             }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
-            t.nextLap();
-        }
-        std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
-    }
+            std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
 
-    {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+            std::cout << std::endl;
+        }
+
+        // CPU with OpenMP
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                #pragma omp parallel for reduction(+:sum)
+                for (int i = 0; i < n; ++i) {
+                    sum += as[i];
+                }
+                EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+            std::cout << std::endl;
+        }
+
+        {
+            // TODO: implement on OpenCL
+            gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+            gpu::Context context;
+            context.init(device.device_id_opencl);
+            context.activate();
+
+            gpu::gpu_mem_32u as_gpu;
+            gpu::gpu_mem_32u sum_gpu;
+
+            as_gpu.resizeN(n);
+            sum_gpu.resizeN(1);
+
+            as_gpu.writeN(as.data(), n);
+
+            // GPU with global atomic
+            runGpuKernel(benchmarkingIters, "sum_gpu_global_atomic", gpu::WorkSize(128, n), as_gpu, sum_gpu, n, reference_sum);
+
+            // // GPU with cycle
+            runGpuKernel(benchmarkingIters, "sum_gpu_cycle", gpu::WorkSize(128, n / 64), as_gpu, sum_gpu, n, reference_sum);
+
+            // GPU with coalesed cycle
+            runGpuKernel(benchmarkingIters, "sum_gpu_coalesed_cycle", gpu::WorkSize(128, n / 64), as_gpu, sum_gpu, n, reference_sum);
+
+            // GPU with local buffer
+            runGpuKernel(benchmarkingIters, "sum_gpu_local", gpu::WorkSize(128, n), as_gpu, sum_gpu, n, reference_sum);
+
+            // GPU with tree
+            runGpuKernel(benchmarkingIters, "sum_gpu_tree", gpu::WorkSize(128, n), as_gpu, sum_gpu, n, reference_sum);
+        }
+    }
+    catch(const std::exception& err) {
+        std::cerr << err.what() << std::endl;
+        throw;
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -51,8 +51,8 @@ void runGpuKernel(
         EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
         t.nextLap();
     }
-    std::cout << "GPU <" << kernel_name << ">: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-    std::cout << "GPU <" << kernel_name << ">: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    std::cout << "GPU " << kernel_name << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU " << kernel_name << ": " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
 
     std::cout << std::endl;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./aplusb 3
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #2: GPU. Intel(R) UHD Graphics 620. Total memory: 6507 Mb
  Device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Using device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Data generated for n=50000000!
Just example of printf usage: WARP_SIZE=32


$ ./mandelbrot 3
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #2: GPU. Intel(R) UHD Graphics 620. Total memory: 6507 Mb
  Device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Using device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
CPU: 1.17033+-0.0566265 s
CPU: 8.54457 GFlops
    Real iterations fraction: 56.2638%
Building kernels for NVIDIA GeForce MX150...
Kernels compilation done in 0.023 seconds
Device 1
        Program build log:

GPU: 0.0296667+-0.00124722 s
GPU: 337.079 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%


$ ./sum 3
CPU:     1.00767+-0.156394 s
CPU:     99.2392 millions/s

CPU OMP: 0.157167+-0.00323608 s
CPU OMP: 636.267 millions/s

OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #2: GPU. Intel(R) UHD Graphics 620. Total memory: 6507 Mb
  Device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Using device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
GPU sum_gpu_global_atomic: 0.0168333+-0.000372678 s
GPU sum_gpu_global_atomic: 5940.59 millions/s

GPU sum_gpu_cycle: 0.025+-4.65661e-10 s
GPU sum_gpu_cycle: 4000 millions/s

GPU sum_gpu_coalesed_cycle: 0.012+-1.64636e-10 s
GPU sum_gpu_coalesed_cycle: 8333.33 millions/s

GPU sum_gpu_local: 0.0173333+-0.000471405 s
GPU sum_gpu_local: 5769.23 millions/s

GPU sum_gpu_tree: 0.0286667+-0.000471405 s
GPU sum_gpu_tree: 3488.37 millions/s
</pre>

</p></details>


<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./aplusb
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=50000000!
Just example of printf usage: WARP_SIZE=1



./mandelbrot
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.602417+-7.92852e-05 s
CPU: 16.5998 GFlops
    Real iterations fraction: 56.2638%
Building kernels for AMD EPYC 7763 64-Core Processor                ... 
Kernels compilation done in 0.036696 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (8)
Done.

GPU: 0.16385+-0.00017335 s
GPU: 61.0312 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%


$ ./sum
CPU:     0.0322087+-9.80215e-05 s
CPU:     3104.75 millions/s

CPU OMP: 0.0176648+-0.00010242 s
CPU OMP: 5660.96 millions/s

OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU sum_gpu_global_atomic: 1.41154+-0.000363132 s
GPU sum_gpu_global_atomic: 70.8448 millions/s

GPU sum_gpu_cycle: 0.0274223+-8.07045e-05 s
GPU sum_gpu_cycle: 3646.66 millions/s

GPU sum_gpu_coalesed_cycle: 0.024218+-1.[9](https://github.com/GPGPUCourse/GPGPUTasks2024/pull/98/checks#step:9:10)7906e-05 s
GPU sum_gpu_coalesed_cycle: 4129.16 millions/s

GPU sum_gpu_local: 0.0347838+-7.6656e-05 s
GPU sum_gpu_local: 2874.9 millions/s

GPU sum_gpu_tree: 0.162953+-0.000[10](https://github.com/GPGPUCourse/GPGPUTasks2024/pull/98/checks#step:9:11)2477 s
GPU sum_gpu_tree: 613.673 millions/s
</pre>

</p></details>