### PR TITLE
Task03 Petr Ivanov ITMO

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,46 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(const float sizeX,
+                         const float sizeY,
+                         const unsigned int width,
+                         const unsigned int height,
+                         const float fromX,
+                         const float fromY,
+                         const unsigned int iters,
+                         unsigned int smoothing, // а где bool?
+                         __global float* results)
 {
-    // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
-    // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
-    // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
-    // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const unsigned int idx = get_global_id(0);
+    const unsigned int idy = get_global_id(1);
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    if (idx >= width || idy >= height)
+        return;
+
+    float x0 = fromX + (idx + 0.5f) * sizeX / width;  // как же я пожалел, что впихнул сюда тернарный оператор...
+    float y0 = fromY + (idy + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[idy * width + idx] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,92 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+#define TASK_SIZE 96
+#define WORKGROUP_SIZE 128
+
+__kernel void global_atomic_sum(__global unsigned int* nums, __global unsigned int* result, const unsigned int n)
+{
+    const unsigned int idx = get_global_id(0);
+
+    if (idx >= n)
+        return;
+
+    atomic_add(result, nums[idx]);
+}
+
+__kernel void global_looped_sum(__global unsigned int* nums, __global unsigned int* result, const unsigned int n)
+{
+    const unsigned int idx = get_global_id(0);
+
+    unsigned int internal_sum = 0;
+
+    for (int i = 0; i < TASK_SIZE; i++)
+    {
+        if (i * get_global_size(0) + idx >= n) break;
+        internal_sum += nums[i * get_global_size(0) + idx];
+    }
+    atomic_add(result, internal_sum);
+}
+
+__kernel void global_looped_coalesced_sum(__global unsigned int* nums, __global unsigned int* result, const unsigned int n)
+{
+    const unsigned int idx = get_global_id(0);
+
+    unsigned int internal_sum = 0;
+
+    for (int i = idx * TASK_SIZE; i < (idx + 1) * TASK_SIZE; i++)
+    {
+        if (i >= n) break;
+        internal_sum += nums[i];
+    }
+    atomic_add(result, internal_sum);
+}
+
+__kernel void local_mem_sum(__global unsigned int* nums, __global unsigned int* result, const unsigned int n)
+{
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int lidx = get_local_id(0);
+
+    __local unsigned int groupData[WORKGROUP_SIZE];
+
+    groupData[lidx] = gidx < n ? nums[gidx] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lidx == 0)
+    {
+        unsigned int groupResult = 0;
+        for (int i = 0; i < WORKGROUP_SIZE; ++i)
+            groupResult += groupData[i];
+        atomic_add(result, groupResult);
+    }
+}
+
+__kernel void tree_local_mem_sum(__global unsigned int* nums, __global unsigned int* result, const unsigned int n)
+{
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int lidx = get_local_id(0);
+
+    __local unsigned int groupData[WORKGROUP_SIZE];
+
+    groupData[lidx] = gidx < n ? nums[gidx] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int i = 0; i < (int)ceil(log2((float)WORKGROUP_SIZE)); ++i)
+    {
+        unsigned int step = (int)pow(2.0f, i);
+        if ((lidx % step == 0) && (lidx / step % 2 == 0))
+        {
+            groupData[lidx] = groupData[lidx] + groupData[lidx + step];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lidx == 0)
+    {
+        atomic_add(result, groupData[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,46 +106,77 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f results_gpu;
+        results_gpu.resizeN(width * height);
+
+        unsigned int workGroupSize = 16;
+        unsigned int globalWorkSizeX = (width + workGroupSize - 1) / workGroupSize * workGroupSize;
+        unsigned int globalWorkSizeY = (height + workGroupSize - 1) / workGroupSize * workGroupSize;
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(workGroupSize, workGroupSize, globalWorkSizeX, globalWorkSizeY),
+                    sizeX, sizeY, width, height, centralX - sizeX / 2.0f,
+                    centralY - sizeY / 2.0f, iterationsLimit, 1, results_gpu);
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        results_gpu.readN(gpu_results.ptr(), width * height);
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_cpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // bool useGPU = true;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }
@@ -180,10 +211,8 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
                           iterationsLimit, true);
         } else {
             kernel.exec(gpu::WorkSize(16, 16, width, height),
-                        results_vram, width, height,
-                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                        sizeX, sizeY,
-                        iterationsLimit, 1);
+                                sizeX, sizeY, width, height, centralX - sizeX / 2.0f,
+                                centralY - sizeY / 2.0f, iterationsLimit, 1, results_vram);
             results_vram.readN(results.ptr(), width * height);
         }
         renderToColor(results.ptr(), image.ptr(), width, height);

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,13 @@
+#include "libgpu/context.h"
+
+
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include "libgpu/shared_device_buffer.h"
+
+#include "cl/sum_cl.h"
 
 
 template<typename T>
@@ -17,6 +24,11 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
@@ -59,6 +71,100 @@ int main(int argc, char **argv)
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::gpu_mem_32u as_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+        gpu::gpu_mem_32u result_gpu;
+        result_gpu.resizeN(1);
+
+        unsigned int workGroupSize = 128;
+        constexpr unsigned int TASK_SIZE = 96;
+
+        {
+            ocl::Kernel global_atomic_sum_kernel(sum_kernel, sum_kernel_length, "global_atomic_sum");
+            global_atomic_sum_kernel.compile(false);
+            unsigned int globalWorkSizeX = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            timer t;
+            unsigned int gpu_result = 0;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                result_gpu.writeN(&gpu_result, 1);
+                global_atomic_sum_kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSizeX), as_gpu, result_gpu, n);
+                t.nextLap();
+            }
+            std::cout << "GPU (global atomic):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (global atomic):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            result_gpu.readN(&gpu_result, 1);
+            EXPECT_THE_SAME(reference_sum, gpu_result, "CPU and GPU results should be consistent!");
+        }
+
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "global_looped_sum");
+            kernel.compile(false);
+            unsigned int globalWorkSizeX = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            globalWorkSizeX = (globalWorkSizeX + TASK_SIZE - 1) / TASK_SIZE;
+            timer t;
+            unsigned int gpu_result = 0;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                result_gpu.writeN(&gpu_result, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSizeX), as_gpu, result_gpu, n);
+                t.nextLap();
+            }
+            std::cout << "GPU (global looped):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (global looped):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            result_gpu.readN(&gpu_result, 1);
+            EXPECT_THE_SAME(reference_sum, gpu_result, "CPU and GPU results should be consistent!");
+        }
+
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "global_looped_coalesced_sum");
+            kernel.compile(false);
+            unsigned int globalWorkSizeX = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            globalWorkSizeX = (globalWorkSizeX + TASK_SIZE - 1) / TASK_SIZE;
+            timer t;
+            unsigned int gpu_result = 0;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                result_gpu.writeN(&gpu_result, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSizeX), as_gpu, result_gpu, n);
+                t.nextLap();
+            }
+            std::cout << "GPU (global coalesced looped):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (global coalesced looped):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            result_gpu.readN(&gpu_result, 1);
+            EXPECT_THE_SAME(reference_sum, gpu_result, "CPU and GPU results should be consistent!");
+        }
+
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "local_mem_sum");
+            kernel.compile(false);
+            unsigned int globalWorkSizeX = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            timer t;
+            unsigned int gpu_result = 0;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                result_gpu.writeN(&gpu_result, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSizeX), as_gpu, result_gpu, n);
+                t.nextLap();
+            }
+            std::cout << "GPU (local mem):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (local mem):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            result_gpu.readN(&gpu_result, 1);
+            EXPECT_THE_SAME(reference_sum, gpu_result, "CPU and GPU results should be consistent!");
+        }
+
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "tree_local_mem_sum");
+            kernel.compile(false);
+            unsigned int globalWorkSizeX = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            timer t;
+            unsigned int gpu_result = 0;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                result_gpu.writeN(&gpu_result, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSizeX), as_gpu, result_gpu, n);
+                t.nextLap();
+            }
+            std::cout << "GPU (tree local mem):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (tree local mem):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            result_gpu.readN(&gpu_result, 1);
+            EXPECT_THE_SAME(reference_sum, gpu_result, "CPU and GPU results should be consistent!");
+        }
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
/home/peter/GPGPUTasks2024/cmake-build-debug/mandelbrot
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
Using device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
CPU: 0.348256+-0.00654399 s
CPU: 28.7145 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.000609333+-9.42809e-07 s
GPU: 16411.4 GFlops
    Real iterations fraction: 56.0919%
GPU vs CPU average results difference: 1.0902%

/home/peter/GPGPUTasks2024/cmake-build-debug/sum
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
Using device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
CPU:     0.125239+-0.000968188 s
CPU:     798.475 millions/s
CPU OMP: 0.025346+-0.000215669 s
CPU OMP: 3945.4 millions/s
GPU (global atomic):     0.00194733+-4.71405e-07 s
GPU (global atomic):     51352.3 millions/s
GPU (global looped):     0.00145883+-9.15454e-06 s
GPU (global looped):     68547.9 millions/s
GPU (global coalesced looped):     0.0004645+-4.57347e-06 s
GPU (global coalesced looped):     215285 millions/s
GPU (local mem):     0.000597833+-3.23608e-06 s
GPU (local mem):     167271 millions/s
GPU (tree local mem):     0.00121+-2.58199e-06 s
GPU (tree local mem):     82644.6 millions/s
</pre>
</p></details>

Глобальный цикл с coalesced-доступом оказался быстрее... Странно, сумма деревом выглядела как что-то быстрое (хотя там далеко не все потоки работают)

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./mandelbrot
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.603053+-0.000438962 s
CPU: 16.5823 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.169087+-0.00034251 s
GPU: 59.1412 GFlops
    Real iterations fraction: 56.0918%
GPU vs CPU average results difference: 1.09087%

Run ./sum
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU:     0.0323905+-0.000545886 s
CPU:     3087.32 millions/s
CPU OMP: 0.0173325+-0.000204348 s
CPU OMP: 5769.51 millions/s
GPU (global atomic):     1.4137+-0.00053802 s
GPU (global atomic):     70.7364 millions/s
GPU (global looped):     0.02825+-3.35211e-05 s
GPU (global looped):     3539.82 millions/s
GPU (global coalesced looped):     0.0451315+-0.000256429 s
GPU (global coalesced looped):     2215.75 millions/s
GPU (local mem):     0.0376587+-8.9632e-05 s
GPU (local mem):     2655.43 millions/s
GPU (tree local mem):     0.718178+-0.000534492 s
GPU (tree local mem):     139.241 millions/s
</pre>
</p></details>
