### PR TITLE
Task03 Артем Сидоренко HSE

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,8 +4,42 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results,
+                         unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters, int smoothing)
 {
+    const size_t idx = get_global_id(0);
+    const size_t i = idx % width;
+    const size_t j = idx / width;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,101 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void global_atomic_add(__global const unsigned int* as,
+                                    __global unsigned int* sum,
+                                    unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    if (gid >= n) {
+        return;
+    }
+    atomic_add(sum, as[gid]);
+}
+
+#define VALUES_PER_WORKITEM 64
+__kernel void cycled(__global const unsigned int* as,
+                     __global unsigned int* sum,
+                     unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += as[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+#define VALUES_PER_WORKITEM 64
+__kernel void cycled_coalesced(__global const unsigned int* as,
+                     __global unsigned int* sum,
+                     unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += as[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+#define WORKGROUP_SIZE 128
+__kernel void local_mem_with_main_thread(__global const unsigned int* as,
+                     __global unsigned int* sum,
+                     unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = as[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (int i = 0; i < WORKGROUP_SIZE; i++) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+#define WORKGROUP_SIZE 128
+__kernel void tree(__global const unsigned int* as,
+                     __global unsigned int* sum,
+                     unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+    const unsigned int wid = get_group_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? as[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int i = WORKGROUP_SIZE; i > 1; i /=2) {
+        if (lid * 2 < i) {
+            buf[lid] += buf[lid + i / 2];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -9,16 +9,15 @@
 #include "cl/mandelbrot_cl.h"
 
 
-void mandelbrotCPU(float* results,
+void mandelbrotCPU(float *results,
                    unsigned int width, unsigned int height,
                    float fromX, float fromY,
                    float sizeX, float sizeY,
-                   unsigned int iters, bool smoothing)
-{
+                   unsigned int iters, bool smoothing) {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
-    #pragma omp parallel for
+
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -47,13 +46,12 @@ void mandelbrotCPU(float* results,
     }
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb, unsigned int width, unsigned int height);
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height);
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU);
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     unsigned int benchmarkingIters = 10;
@@ -89,7 +87,7 @@ int main(int argc, char **argv)
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
@@ -99,47 +97,87 @@ int main(int argc, char **argv)
                 realIterationsFraction += cpu_results.ptr()[j * width + i];
             }
         }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
 
         renderToColor(cpu_results.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_cpu.png");
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        size_t result_sz = width * height;
+        gpu::gpu_mem_32f gpu_result_buf;
+        gpu_result_buf.resizeN(result_sz);
+
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (result_sz + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                        gpu_result_buf,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit, 0
+            );
+            t.nextLap();
+        }
+
+        gpu_result_buf.readN(gpu_results.ptr(), result_sz);
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000 * 1000 * 1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
@@ -150,8 +188,7 @@ int main(int argc, char **argv)
     return 0;
 }
 
-void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
-{
+void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU) {
     images::ImageWindow window("Mandelbrot");
 
     unsigned int width = 1024;
@@ -194,7 +231,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         if (window.getMouseClick() == MOUSE_LEFT) {
             centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
             centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
+            std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
         }
         if (window.isResized()) {
             window.resize();
@@ -220,7 +257,9 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 struct vec3f {
     vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
 vec3f operator+(const vec3f &a, const vec3f &b) {
@@ -247,10 +286,9 @@ vec3f cos(const vec3f &a) {
     return {cosf(a.x), cosf(a.y), cosf(a.z)};
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
-{
-    #pragma omp parallel for
+void renderToColor(const float *results, unsigned char *img_rgb,
+                   unsigned int width, unsigned int height) {
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -259,7 +297,7 @@ void renderToColor(const float* results, unsigned char* img_rgb,
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
             img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
             img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
             img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,13 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include "libgpu/context.h"
+#include "libgpu/shared_device_buffer.h"
 
+#include "cl/sum_cl.h"
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -14,13 +16,19 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+void benchKernelName(const std::string &kernel_name,
+                     int benchmarking_iters,
+                     unsigned int n,
+                     const gpu::gpu_mem_32u &gpu_as,
+                     unsigned int wg_size,
+                     unsigned int gw_size,
+                     unsigned int reference_sum);
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -39,14 +47,14 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+:sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
@@ -54,11 +62,57 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u gpu_as;
+        gpu_as.resizeN(n);
+        gpu_as.writeN(as.data(), n);
+
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+        benchKernelName("global_atomic_add", benchmarkingIters, n, gpu_as, workGroupSize, global_work_size,
+                        reference_sum);
+        benchKernelName("cycled", benchmarkingIters, n, gpu_as, workGroupSize, global_work_size / 64, reference_sum);
+        benchKernelName("cycled_coalesced", benchmarkingIters, n, gpu_as, workGroupSize, global_work_size / 64,
+                        reference_sum);
+        benchKernelName("local_mem_with_main_thread", benchmarkingIters, n, gpu_as, workGroupSize, global_work_size,
+                        reference_sum);
+        benchKernelName("tree", benchmarkingIters, n, gpu_as, workGroupSize, global_work_size, reference_sum);
     }
+}
+
+void benchKernelName(const std::string &kernel_name,
+                     int benchmarking_iters,
+                     unsigned int n,
+                     const gpu::gpu_mem_32u &gpu_as,
+                     unsigned int wg_size,
+                     unsigned int gw_size,
+                     unsigned int reference_sum) {
+    ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+    timer t;
+
+    gpu::gpu_mem_32u gpu_sum;
+    gpu_sum.resizeN(1);
+
+    for (int iter = 0; iter < benchmarking_iters; ++iter) {
+        unsigned int sum = 0;
+        gpu_sum.writeN(&sum, 1);
+        kernel.exec(gpu::WorkSize(wg_size, gw_size),
+                    gpu_as,
+                    gpu_sum,
+                    n);
+        gpu_sum.readN(&sum, 1);
+        EXPECT_THE_SAME(reference_sum, sum, "GPU global_atomic_add result should be consistent!");
+        t.nextLap();
+    }
+    std::cout << "GPU " + kernel_name + ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU " + kernel_name + ": " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\mandelbrot.exe 0
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
CPU: 0.298833+-0.0035316 s
CPU: 33.4635 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.045+-0.00057735 s
GPU: 222.222 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\mandelbrot.exe 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
CPU: 0.296833+-0.00157233 s
CPU: 33.6889 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.00183333+-0.000372678 s
GPU: 5454.55 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%

</pre>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\mandelbrot.exe 2
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
CPU: 0.314167+-0.0140762 s
CPU: 31.8302 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0158333+-0.000372678 s
GPU: 631.579 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0%

</pre>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\sum.exe 0
CPU:     0.209167+-0.000687184 s
CPU:     478.088 millions/s
CPU OMP: 0.0261667+-0.000687184 s
CPU OMP: 3821.66 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
GPU global_atomic_add: 0.796833+-0.00233928 s
GPU global_atomic_add: 125.497 millions/s
GPU cycled: 0.0161667+-0.000372678 s
GPU cycled: 6185.57 millions/s
GPU cycled_coalesced: 0.016+-0 s
GPU cycled_coalesced: 6250 millions/s
GPU local_mem_with_main_thread: 0.0128333+-0.000372678 s
GPU local_mem_with_main_thread: 7792.21 millions/s
GPU tree: 0.0313333+-0.000471405 s
GPU tree: 3191.49 millions/s

Process finished with exit code 0
</pre>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\sum.exe 1
CPU:     0.213167+-0.000687184 s
CPU:     469.116 millions/s
CPU OMP: 0.026+-0 s
CPU OMP: 3846.15 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
GPU global_atomic_add: 0.00233333+-0.000471405 s
GPU global_atomic_add: 42857.1 millions/s
GPU cycled: 0.00233333+-0.000471405 s
GPU cycled: 42857.1 millions/s
GPU cycled_coalesced: 0.00116667+-0.000372678 s
GPU cycled_coalesced: 85714.3 millions/s
GPU local_mem_with_main_thread: 0.0015+-0.0005 s
GPU local_mem_with_main_thread: 66666.7 millions/s
GPU tree: 0.003+-4.1159e-11 s
GPU tree: 33333.3 millions/s

Process finished with exit code 0
</pre>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\sum.exe 2
CPU:     0.209333+-0.000471405 s
CPU:     477.707 millions/s
CPU OMP: 0.0261667+-0.00121335 s
CPU OMP: 3821.66 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
GPU global_atomic_add: 0.0726667+-0.000745356 s
GPU global_atomic_add: 1376.15 millions/s
GPU cycled: 0.0306667+-0.000471405 s
GPU cycled: 3260.87 millions/s
GPU cycled_coalesced: 0.0103333+-0.000471405 s
GPU cycled_coalesced: 9677.42 millions/s
GPU local_mem_with_main_thread: 0.0378333+-0.000897527 s
GPU local_mem_with_main_thread: 2643.17 millions/s
GPU tree: 0.0168333+-0.000687184 s
GPU tree: 5940.59 millions/s

Process finished with exit code 0

</pre>

</p></details>
<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./mandelbrot
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.59791+-0.000979529 s
CPU: 16.7249 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.165191+-0.000140089 s
GPU: 60.5358 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

<pre>
Run ./sum
CPU:     0.0322192+-8.55286e-05 s
CPU:     3103.74 millions/s
CPU OMP: 0.017493+-0.000112042 s
CPU OMP: 5716.57 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU global_atomic_add: 1.46622+-0.00151503 s
GPU global_atomic_add: 68.2028 millions/s
GPU cycled: 0.028426+-4.50074e-05 s
GPU cycled: 3517.91 millions/s
GPU cycled_coalesced: 0.0253438+-2.80679e-05 s
GPU cycled_coalesced: 3945.73 millions/s
GPU local_mem_with_main_thread: 0.035476+-5.54226e-05 s
GPU local_mem_with_main_thread: 2818.81 millions/s
GPU tree: 0.109956+-0.000323121 s
GPU tree: 909.452 millions/s
</pre>

</p></details>

cycled coalesced mem access победил)

На cpu coalesced mem access дал околонулевой прирост производительности. Чего не скажешь про графические чипы (на интегрированном прирост даже больше чем на дискретном; с разными размерами wg, цикла не успел поэкспериментировать :с). Если смотреть на cpu, то кажется, что здесь обычный цикл тоже coalesced по итогу выходит (ну если потоки шедулятся хорошо, то есть примерно последовательными пачками -- тогда для этих пачек в кеш линейку подгружается нужный кусок массива и кешмиссов не так много).

atomic_add на cpu получился супер медленным (у меня здесь только вариант с большим кол-вом обращений к памяти, часто инвалидируются кеши, на каждую операцию записи нужно идти в память? пропускная способность cpu - ram на порядок ниже, чем gpu - vram, отсюда и различия на порядок?)

дерево и локальная память не выиграли у coalesced. Наверное оверхед на локальные синхронизации больше чем выигрыш по кол-ву обращений к памяти. Но кажется, что зависит от задачи (здесь например относительно мало данных перегоняются, на большем объеме вероятно был бы выигрыш)
