### PR TITLE
Task03 Уткин Илья ITMO

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,52 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, int smoothing,
+    __global float* results
+)
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const int xid = get_global_id(0);
+    const int yid = get_global_id(1);
+
+    if (yid > height || xid > width) return;
+
+    float x0 = fromX + (xid + 0.5f) * sizeX / width;
+    float y0 = fromY + (yid + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    int iter = 0;
+    int result = -1;
+    for (; iter < iters; iter++) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2 && result == -1) {
+            result = iter;
+        }
+    }
+
+    if (result == -1) {
+        result = iters;
+    }
+
+    // float result = iter;
+    // if (smoothing != 0 && iter != iters) {
+    //     result = result - logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
+    // }
+
+    results[yid * width + xid] = 1.0f * result / iters;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,120 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define VALUES_PER_WORKITEM 64
+
+__kernel void sum_global_atomic(
+    __global const unsigned int* a,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n) 
+        return;
+
+    atomic_add(sum, a[gid]);
+}
+
+__kernel void sum_cycle(
+    __global const unsigned int* a,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid > (n - VALUES_PER_WORKITEM) / VALUES_PER_WORKITEM) return;
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        const size_t idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += a[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+__kernel void sum_cycle_coalesce(
+    __global const unsigned int* a,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int wid = get_group_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    if (wid * grs > (n - VALUES_PER_WORKITEM) / VALUES_PER_WORKITEM) return;
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        const unsigned int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += a[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+__kernel void sum_local_mem(
+    __global const unsigned int* a,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int lgs = get_local_size(0);
+    const unsigned int WORKGROUP_SIZE = 128;
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    if (gid < n) {
+        buf[lid] = a[gid];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < get_local_size(0); i++) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+__kernel void sum_tree(
+    __global const unsigned int* a,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int WORKGROUP_SIZE = 128;
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+    
+    if (gid < n) {
+        buf[lid] = a[gid];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues / 2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -5,6 +5,7 @@
 #line 6
 
 #define VALUES_PER_WORKITEM 64
+#define WORKGROUP_SIZE 128
 
 __kernel void sum_global_atomic(
     __global const unsigned int* a,
@@ -68,8 +69,6 @@ __kernel void sum_local_mem(
 ) {
     const unsigned int gid = get_global_id(0);
     const unsigned int lid = get_local_id(0);
-    const unsigned int lgs = get_local_size(0);
-    const unsigned int WORKGROUP_SIZE = 128;
 
     __local unsigned int buf[WORKGROUP_SIZE];
 
@@ -81,7 +80,7 @@ __kernel void sum_local_mem(
 
     if (lid == 0) {
         unsigned int group_res = 0;
-        for (unsigned int i = 0; i < get_local_size(0); i++) {
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; i++) {
             group_res += buf[i];
         }
         atomic_add(sum, group_res);
@@ -96,7 +95,6 @@ __kernel void sum_tree(
     const unsigned int gid = get_global_id(0);
     const unsigned int lid = get_local_id(0);
     const unsigned int wid = get_group_id(0);
-    const unsigned int WORKGROUP_SIZE = 128;
 
     __local unsigned int buf[WORKGROUP_SIZE];
     

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -74,6 +74,7 @@ int main(int argc, char **argv)
     images::Image<float> cpu_results(width, height, 1);
     images::Image<float> gpu_results(width, height, 1);
     images::Image<unsigned char> image(width, height, 3);
+    images::Image<unsigned char> gpu_image(width, height, 3);
 
     float sizeY = sizeX * height / width;
 
@@ -106,40 +107,79 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+   // Раскомментируйте это:
+
+   gpu::Context context;
+   context.init(device.device_id_opencl);
+   context.activate();
+   {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        gpu::gpu_mem_32f result_gpu;
+        result_gpu.resizeN(width * height);
+
+        unsigned int workGroupSizeDim = 16;
+
+        unsigned int globalWorkSizeX = (width + workGroupSizeDim - 1) / workGroupSizeDim * workGroupSizeDim;
+        unsigned int globalWorkSizeY = (height + workGroupSizeDim - 1) / workGroupSizeDim * workGroupSizeDim;
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(
+            gpu::WorkSize(workGroupSizeDim, workGroupSizeDim, globalWorkSizeX, globalWorkSizeY),
+            width, height,
+            centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+            sizeX, sizeY,
+            iterationsLimit, 0,
+            result_gpu
+            );
+            t.nextLap();
+        }
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += cpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        result_gpu.readN(gpu_results.ptr(), width * height);
+
+        renderToColor(gpu_results.ptr(), gpu_image.ptr(), width, height);
+        gpu_image.savePNG("mandelbrot_gpu.png");
+   }
+
+   {
+       double errorAvg = 0.0;
+       for (int j = 0; j < height; ++j) {
+           for (int i = 0; i < width; ++i) {
+               errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+           }
+       }
+       errorAvg /= width * height;
+       std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+       if (errorAvg > 0.03) {
+           throw std::runtime_error("Too high difference between CPU and GPU results!");
+       }
+   }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -21,10 +21,6 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-void testKernel(std::string kernelName) {
-    
-}
-
 
 int main(int argc, char **argv)
 {
@@ -117,7 +113,7 @@ int main(int argc, char **argv)
             host_sum = 0;
             sum_res.writeN(&host_sum, 1);
             kernel.exec(
-                gpu::WorkSize(workGroupSize, globalWorkSize),
+                gpu::WorkSize(workGroupSize, globalWorkSize / 64),
                 a_gpu, 
                 sum_res,
                 n
@@ -139,7 +135,7 @@ int main(int argc, char **argv)
             host_sum = 0;
             sum_res.writeN(&host_sum, 1);
             kernel.exec(
-                gpu::WorkSize(workGroupSize, globalWorkSize),
+                gpu::WorkSize(workGroupSize, globalWorkSize / 64),
                 a_gpu, 
                 sum_res,
                 n

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,12 @@
+#include "libgpu/device.h"
+#include <libgpu/context.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+
+#include "cl/sum_cl.h"
+#include "libgpu/shared_device_buffer.h"
+#include "libgpu/work_size.h"
 
 
 template<typename T>
@@ -13,6 +19,11 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
+
+
+void testKernel(std::string kernelName) {
+    
+}
 
 
 int main(int argc, char **argv)
@@ -57,8 +68,131 @@ int main(int argc, char **argv)
         std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
-    {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    gpu::gpu_mem_32u a_gpu;
+    a_gpu.resizeN(n);
+    a_gpu.writeN(as.data(), n);
+
+    unsigned int host_sum = 0;
+
+    gpu::gpu_mem_32u sum_res;
+    sum_res.resizeN(1);
+    sum_res.writeN(&host_sum, 1);
+
+    const unsigned int workGroupSize = 128;
+    const unsigned int globalWorkSize = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+    {        
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_global_atomic");
+        kernel.compile(true);
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            host_sum = 0;
+            sum_res.writeN(&host_sum, 1);
+            kernel.exec(
+                gpu::WorkSize(workGroupSize, globalWorkSize),
+                a_gpu, 
+                sum_res,
+                n
+            );
+            sum_res.readN(&host_sum, 1);
+            EXPECT_THE_SAME(reference_sum, host_sum, "CPU and sum_global_atomic results should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU sum_global_atomic: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU sum_global_atomic: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+
+    {        
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_cycle");
+        kernel.compile(false);
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            host_sum = 0;
+            sum_res.writeN(&host_sum, 1);
+            kernel.exec(
+                gpu::WorkSize(workGroupSize, globalWorkSize),
+                a_gpu, 
+                sum_res,
+                n
+            );
+            sum_res.readN(&host_sum, 1);
+            EXPECT_THE_SAME(reference_sum, host_sum, "CPU and sum_cycle results should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU sum_cycle: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU sum_cycle: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+
+    {        
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_cycle_coalesce");
+        kernel.compile(false);
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            host_sum = 0;
+            sum_res.writeN(&host_sum, 1);
+            kernel.exec(
+                gpu::WorkSize(workGroupSize, globalWorkSize),
+                a_gpu, 
+                sum_res,
+                n
+            );
+            sum_res.readN(&host_sum, 1);
+            EXPECT_THE_SAME(reference_sum, host_sum, "CPU and sum_cycle_coalesce results should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU sum_cycle_coalesce: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU sum_cycle_coalesce: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+
+    {        
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_local_mem");
+        kernel.compile(false);
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            host_sum = 0;
+            sum_res.writeN(&host_sum, 1);
+            kernel.exec(
+                gpu::WorkSize(workGroupSize, globalWorkSize),
+                a_gpu, 
+                sum_res,
+                n
+            );
+            sum_res.readN(&host_sum, 1);
+            EXPECT_THE_SAME(reference_sum, host_sum, "CPU and sum_local_mem results should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU sum_local_mem: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU sum_local_mem: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+
+    {        
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_tree");
+        kernel.compile(false);
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            host_sum = 0;
+            sum_res.writeN(&host_sum, 1);
+            kernel.exec(
+                gpu::WorkSize(workGroupSize, globalWorkSize),
+                a_gpu, 
+                sum_res,
+                n
+            );
+            sum_res.readN(&host_sum, 1);
+            EXPECT_THE_SAME(reference_sum, host_sum, "CPU and sum_tree results should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU sum_tree: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU sum_tree: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 }


### PR DESCRIPTION
Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <sum_global_atomic> was successfully vectorized (8)
Kernel <sum_cycle> was not vectorized
Kernel <sum_cycle_coalesce> was successfully vectorized (8)
Kernel <sum_local_mem> was successfully vectorized (8)
Kernel <sum_tree> was successfully vectorized (8)
Done.

Runtime:
Бейзлайн. Все операции суммирования стоят в очереди и драйвер никак не захотет это оптимизировать
GPU sum_global_atomic: 2.36046+-0.0251082 s
GPU sum_global_atomic: 42.3647 millions/s

Разбили работу на несколько групп и в разы сократили количество атомарных сложений. Получили существенный буст. Однако судя из билд лога у компиятора не получилось векторизовать эту операцию
GPU sum_cycle: 0.0818463+-0.001403 s
GPU sum_cycle: 1221.8 millions/s

Здесь уже получилось векторизовать кернел, получили еще буст.
GPU sum_cycle_coalesce: 0.0582893+-0.0026487 s
GPU sum_cycle_coalesce: 1715.58 millions/s

Пользуемся локальным кэшем. Удивлен что дало буст учитывая что запускаюсь на цпу. Видимо VRAM мапится в RAM а кэш гпу в кэш процесора.
GPU sum_local_mem: 0.0461117+-0.00118241 s
GPU sum_local_mem: 2168.65 millions/s

Дерево на ЦПУ дает не особо хороший буст по сравнению с бейзлайном.
GPU sum_tree: 0.162337+-0.00387873 s
GPU sum_tree: 616.001 millions/s