### PR TITLE
Task03 Георгий Кашин ИТМО

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -24,7 +24,7 @@ __kernel void mandelbrot(__global float* results,
     }
 
     float x0 = fromX + (i + 0.5f) * sizeX / width;
-    float y0 = fromY + (i + 0.5f) * sizeY / height;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
 
     float x = x0;
     float y = y0;

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,43 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(__global float* results,
+                         unsigned int width,
+                         unsigned int height,
+                         float fromX, float fromY, float sizeX, float sizeY, unsigned int iters, int smoothing) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    const int i = get_global_id(0);
+    const int j = get_global_id(1);
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (i + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -7,7 +7,7 @@
 __kernel void mandelbrot(__global float* results,
                          unsigned int width,
                          unsigned int height,
-                         float fromX, float fromY, float sizeX, float sizeY, unsigned int iters, int smoothing) {
+                         float fromX, float fromY, float sizeX, float sizeY, unsigned int iters) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
@@ -37,9 +37,6 @@ __kernel void mandelbrot(__global float* results,
     }
 
     float result = iter;
-    if (smoothing && iter != iters) {
-        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
-    }
 
     result = 1.0f * result / iters;
     results[j * width + i] = result;

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -19,6 +19,10 @@ __kernel void mandelbrot(__global float* results,
     const int i = get_global_id(0);
     const int j = get_global_id(1);
 
+    if (i >= width || j >= height) {
+        return;
+    }
+
     float x0 = fromX + (i + 0.5f) * sizeX / width;
     float y0 = fromY + (i + 0.5f) * sizeY / height;
 

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -68,7 +68,7 @@ __kernel void sum_local_mem_main_thread(
         __global unsigned int* sum,
         unsigned int n
 ) {
-    __local unsigned int buff[128];
+    __local unsigned int buff[WORKGROUP_SIZE];
     const unsigned int ggi = get_global_id(0);
     const unsigned int gli = get_local_id(0);
     const unsigned int gls = get_local_size(0);

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,4 +1,5 @@
 #define VALUES_PER_WORK_ITEM 64
+#define WORKGROUP_SIZE 128
 
 __kernel void sum_global_atomic_add(
     __global unsigned int* input,

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -110,7 +110,7 @@ __kernel void sum_tree(
 
     for (int i = work_group_size; i > 1; i /= 2) {
         if (i > 2 * gli) {
-            buff[gli] += buff[gli + i / 2];
+            buff[gli] = buff[gli] + buff[gli + i / 2];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -102,6 +102,8 @@ __kernel void sum_tree(
 
     if (ggi < n) {
         buff[gli] = input[ggi];
+    } else {
+        buff[gli] = 0;
     }
 
     barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,38 @@
-// TODO
+const unsigned int VALUES_PER_WORK_ITEM = 64;
+
+__kernel void sum_global_atomic_add(
+    __global unsigned int* input,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n) {
+        return;
+    }
+
+    atomic_add(sum, input[gid]);
+}
+
+__kernel void sum_cycle(
+    __global unsigned int* input,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid > (n - VALUES_PER_WORK_ITEM) / VALUES_PER_WORK_ITEM) {
+        return;
+    }
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORK_ITEM; i++) {
+        const size_t idx = gid * VALUES_PER_WORK_ITEM + i;
+
+        if (idx < n) {
+            result += input[idx];
+        }
+    }
+
+    atomic_add(sum, result);
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -85,7 +85,7 @@ __kernel void sum_local_mem_main_thread(
             result += buff[i];
         }
 
-        atomic_add(sum, buff);
+        atomic_add(sum, result);
     }
 }
 

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,4 +1,4 @@
-#define VALUES_PER_WORK_ITEM 64;
+#define VALUES_PER_WORK_ITEM 64
 
 __kernel void sum_global_atomic_add(
     __global unsigned int* input,

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,4 +1,4 @@
-const unsigned int VALUES_PER_WORK_ITEM = 64;
+#define VALUES_PER_WORK_ITEM 64;
 
 __kernel void sum_global_atomic_add(
     __global unsigned int* input,
@@ -25,7 +25,7 @@ __kernel void sum_cycle(
         return;
     }
 
-    unsigned int res = 0;
+    unsigned int result = 0;
     for (int i = 0; i < VALUES_PER_WORK_ITEM; i++) {
         const size_t idx = gid * VALUES_PER_WORK_ITEM + i;
 

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -46,7 +46,7 @@ __kernel void sum_cycle_coalesced(
     const unsigned int gli = get_local_id(0);
     const unsigned int gls = get_local_size(0);
 
-    if (ggi * grs > (n - VALUES_PER_WORK_ITEM) / VALUES_PER_WORK_ITEM) {
+    if (ggi * gls > (n - VALUES_PER_WORK_ITEM) / VALUES_PER_WORK_ITEM) {
         return;
     }
 

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -36,3 +36,28 @@ __kernel void sum_cycle(
 
     atomic_add(sum, result);
 }
+
+__kernel void sum_cycle_coalesced(
+        __global unsigned int* input,
+        __global unsigned int* sum,
+        unsigned int n
+) {
+    const unsigned int ggi = get_group_id(0);
+    const unsigned int gli = get_local_id(0);
+    const unsigned int gls = get_local_size(0);
+
+    if (ggi * grs > (n - VALUES_PER_WORK_ITEM) / VALUES_PER_WORK_ITEM) {
+        return;
+    }
+
+    unsigned int result = 0;
+    for (int i = 0; i < VALUES_PER_WORK_ITEM; i++) {
+        const unsigned int idx = ggi * gls * VALUES_PER_WORK_ITEM + gls + gli * i;
+
+        if (idx < n) {
+            result += input[idx];
+        }
+    }
+
+    atomic_add(sum, result);
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -128,14 +128,14 @@ int main(int argc, char **argv)
         gpu::gpu_mem_32f gpu_res;
         gpu_res.resizeN(width * height);
 
-        unsigned int workGroupSize = 32;
+        unsigned int workGroupSize = 16;
         unsigned int workSpaceWidth = (width + workGroupSize - 1) / workGroupSize * workGroupSize;
         unsigned int workSpaceHeight = (height + workGroupSize - 1) / workGroupSize * workGroupSize;
         gpu::WorkSize ws = gpu::WorkSize(workGroupSize, workGroupSize, workSpaceWidth, workSpaceHeight);
 
         timer t;
         for (int i = 0; i < benchmarkingIters; i++) {
-            kernel.exec(ws, gpu_res, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
+            kernel.exec(ws, gpu_res, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit);
             t.nextLap();
         }
 

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << maxAppropriateFlops / gFlops / t.lapAvg() << " Gflops" << std::endl;
 
-        gpu_results_gpu.readN(gpu_results.ptr(), width * height);
+        gpu_res.readN(gpu_results.ptr(), width * height);
 
         double realIterationsFraction = 0.0;
         for (int j = 0; j < height; j++) {

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,72 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        gpu::gpu_mem_32f gpu_res;
+        gpu_res.resizeN(width * height);
+
+        unsigned int workGroupSize = 32;
+        unsigned int workSpaceWidth = (width + workGroupSize - 1) / workGroupSize * workGroupSize;
+        unsigned int workSpaceHeight = (height + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu::WorkSize ws = gpu::WorkSize(workGroupSize, workGroupSize, workSpaceWidth, workSpaceHeight);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; i++) {
+            kernel.exec(ws, gpu_res, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
+            t.nextLap();
+        }
+
+        size_t flopsInLoop = 10;
+        size_t maxAppropriateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gFlops = 1000 * 1000 * 1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxAppropriateFlops / gFlops / t.lapAvg() << " Gflops" << std::endl;
+
+        gpu_results_gpu.readN(gpu_results.ptr(), width * height);
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; j++) {
+            for (int i = 0; i < width; i++) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -147,13 +147,6 @@ int main(int argc, char **argv)
 
         gpu_res.readN(gpu_results.ptr(), width * height);
 
-        double realIterationsFraction = 0.0;
-        for (int j = 0; j < height; j++) {
-            for (int i = 0; i < width; i++) {
-                realIterationsFraction += gpu_results.ptr()[j * width + i];
-            }
-        }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
         renderToColor(gpu_results.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_gpu.png");
     }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -106,6 +106,6 @@ int main(int argc, char **argv)
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle_coalesced");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_local_mem_main_thread");
-//        exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_tree");
+        exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_tree");
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -106,6 +106,6 @@ int main(int argc, char **argv)
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle_coalesced");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_local_mem_main_thread");
-        exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_tree");
+//        exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_tree");
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -50,7 +50,7 @@ void exec_kernel(std::vector<unsigned int> as,
         t.nextLap();
     }
 
-    std::cout << "GPU " << name << ": " <<  << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU " << name << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
     std::cout << "GPU " << name << ": " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
 }
 

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -105,5 +105,6 @@ int main(int argc, char **argv)
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_global_atomic_add");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle_coalesced");
+        exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_local_mem_main_thread");
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -41,11 +41,11 @@ void exec_kernel(std::vector<unsigned int> as,
     timer t;
     for (int iter = 0; iter < benchmarkingIters; iter++) {
         sum = 0;
-        sum_res.writeN(&sum, 1);
+        sum_gpu.writeN(&sum, 1);
 
-        kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSize), sum_gpu, sum_res, n);
+        kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSize), as_gpu, sum_gpu, n);
 
-        sum_res.readN(&sum, 1);
+        sum_gpu.readN(&sum, 1);
         EXPECT_THE_SAME(reference_sum, sum, "GPU results should be consistent!");
         t.nextLap();
     }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -106,5 +106,6 @@ int main(int argc, char **argv)
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle_coalesced");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_local_mem_main_thread");
+        exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_tree");
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -24,7 +24,7 @@ void exec_kernel(std::vector<unsigned int> as,
                  unsigned int reference_sum,
                  int benchmarkingIters,
                  const char* name) {
-    unsigned int workGroupSize = 32;
+    unsigned int workGroupSize = 128;
     gpu::gpu_mem_32u as_gpu;
     as_gpu.resizeN(n);
     as_gpu.writeN(as.data(), n);
@@ -43,7 +43,7 @@ void exec_kernel(std::vector<unsigned int> as,
         sum = 0;
         sum_gpu.writeN(&sum, 1);
 
-        kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSize), as_gpu, sum_gpu, n);
+            kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSize), as_gpu, sum_gpu, n);
 
         sum_gpu.readN(&sum, 1);
         EXPECT_THE_SAME(reference_sum, sum, "GPU results should be consistent!");

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -104,5 +104,6 @@ int main(int argc, char **argv)
 
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_global_atomic_add");
         exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle");
+        exec_kernel(as, n, reference_sum, benchmarkingIters, "sum_cycle_coalesced");
     }
 }


### PR DESCRIPTION
Mandelbrot CI:

```
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.599637+-0.00197356 s
CPU: 16.676 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.154762+-0.00200203 s
GPU: 64.6151 Gflops
GPU vs CPU average results difference: 0.943129%
```

Sum CI:

```
CPU:     0.0323895+-0.000127442 s
CPU:     3087.42 millions/s
CPU OMP: 0.0174415+-6.63495e-05 s
CPU OMP: 5733.45 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Building kernels for AMD EPYC 7763 64-Core Processor                ... 
Kernels compilation done in 0.19583 seconds

GPU sum_global_atomic_add: 1.49081+-0.000208264 s
GPU sum_global_atomic_add: 67.0778 millions/s

GPU sum_cycle: 0.038064+-0.000696038 s
GPU sum_cycle: 2627.15 millions/s

GPU sum_cycle_coalesced: 0.0311477+-0.000659911 s
GPU sum_cycle_coalesced: 3210.51 millions/s

GPU sum_local_mem_main_thread: 0.0589173+-0.000151376 s
GPU sum_local_mem_main_thread: 1697.29 millions/s

GPU sum_tree: 0.164375+-0.000360183 s
GPU sum_tree: 608.366 millions/s
```

Локально запустить не смог (open mp не поставилась почему-то), тестировал в CI.

Самый медленный вариант `sum_global_atomic_add ` логичен, так как каждый поток пытается записать данные атомарно в ячейку памяти.

Самый быстрый способ `sum_cycle_coalesced`, что тоже логично, учитывая coalesced доступ к памяти и без использования local mem.