### PR TITLE
Task03 Степан Остапенко ITMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build
 cmake-build*
 .vs
+.vscode

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,48 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(
+    __global float *results,
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, char smoothing
+) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    int col = get_global_id(0);
+    int row = get_global_id(1);
+
+    if (col >= width || row >= height) {
+        return;
+    }
+
+    float x0 = fromX + (col + 0.5f) * sizeX / width;
+    float y0 = fromY + (row + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[row * width + col] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,125 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+// global atomic
+__kernel void sum_gpu_1(
+    __global const unsigned int *arr,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n) {
+        return;
+    }
+
+    atomic_add(sum, arr[gid]);
+}
+
+#define VALUES_PER_WORKITEM 32
+
+// loop sum
+__kernel void sum_gpu_2(
+    __global const unsigned int *arr,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        unsigned int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+// coalesced loop sum
+__kernel void sum_gpu_3(
+    __global const unsigned int *arr,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        unsigned int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+#define WORKGROUP_SIZE 64
+
+// local memory sum
+__kernel void sum_gpu_4(
+    __global const unsigned int *arr,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = 0;
+    if (gid < n) {
+        buf[lid] = arr[gid];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; i++) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+// tree sum
+__kernel void sum_gpu_5(
+    __global const unsigned int *arr,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = 0;
+    if (gid < n) {
+        buf[lid] = arr[gid];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues / 2];
+            buf[lid] = a + b;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -17,7 +17,7 @@ void mandelbrotCPU(float* results,
 {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
+
     #pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
@@ -66,10 +66,12 @@ int main(int argc, char **argv)
     float centralY = -0.150316f;
     float sizeX = 0.00239f;
 
-//    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
+    /*
+    float centralX = -0.5f;
+    float centralY = 0.0f;
+    float sizeX = 2.0f;
+    */
 
     images::Image<float> cpu_results(width, height, 1);
     images::Image<float> gpu_results(width, height, 1);
@@ -89,7 +91,7 @@ int main(int argc, char **argv)
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
@@ -105,47 +107,84 @@ int main(int argc, char **argv)
         image.savePNG("mandelbrot_cpu.png");
     }
 
+    // Раскомментируйте это:
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+
+        bool printLog = true;
+        kernel.compile(printLog);
+
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        gpu::gpu_mem_32f results_buf;
+        results_buf.resizeN(width * height);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(
+                gpu::WorkSize(8, 8, width, height),
+                results_buf,
+                width, height,
+                centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                sizeX, sizeY,
+                iterationsLimit, false
+            );
+            results_buf.readN(gpu_results.ptr(), width * height);
+
+            t.nextLap();
+        }
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000 * 1000 * 1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
+
+    // bool useGPU = true;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
         run_kernel_benchmark(
             n, as, reference_sum,
             benchmarkingIters, device, global_atomic, "global_atomic",
-            16 * values_per_workitem
+            work_group_size
         );
 
         ocl::Kernel loop_sum(sum_kernel, sum_kernel_length, "sum_gpu_2");
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
         run_kernel_benchmark(
             n, as, reference_sum,
             benchmarkingIters, device, coalesced_loop_sum, "coalesced_loop_sum",
-            work_group_size
+            16 * values_per_workitem
         );
 
         ocl::Kernel local_memory_sum(sum_kernel, sum_kernel_length, "sum_gpu_4");

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -22,10 +22,8 @@ void run_kernel_benchmark(
     unsigned int n, const std::vector<unsigned int> &as,
     unsigned int reference_sum, int benchmarkingIters,
     gpu::Device device, ocl::Kernel kernel, const std::string kernel_name,
-    unsigned int work_group_size
+    unsigned int work_group_size, unsigned int global_work_size
 ) {
-    const unsigned int global_work_size = (n + work_group_size - 1) / work_group_size * work_group_size;
-
     std::cout << std::endl;
     std::cout << "Global work size is " << global_work_size << std::endl;
 
@@ -115,40 +113,41 @@ int main(int argc, char **argv)
 
         const unsigned int values_per_workitem = 32;
         const unsigned int work_group_size = 64;
+        const unsigned int global_work_size = (n + work_group_size - 1) / work_group_size * work_group_size;
 
         ocl::Kernel global_atomic(sum_kernel, sum_kernel_length, "sum_gpu_1");
         run_kernel_benchmark(
             n, as, reference_sum,
             benchmarkingIters, device, global_atomic, "global_atomic",
-            work_group_size
+            work_group_size, global_work_size
         );
 
         ocl::Kernel loop_sum(sum_kernel, sum_kernel_length, "sum_gpu_2");
         run_kernel_benchmark(
             n, as, reference_sum,
             benchmarkingIters, device, loop_sum, "loop_sum",
-            16 * values_per_workitem
+            16 * values_per_workitem, global_work_size / values_per_workitem
         );
 
         ocl::Kernel coalesced_loop_sum(sum_kernel, sum_kernel_length, "sum_gpu_3");
         run_kernel_benchmark(
             n, as, reference_sum,
             benchmarkingIters, device, coalesced_loop_sum, "coalesced_loop_sum",
-            16 * values_per_workitem
+            16 * values_per_workitem, global_work_size / values_per_workitem
         );
 
         ocl::Kernel local_memory_sum(sum_kernel, sum_kernel_length, "sum_gpu_4");
         run_kernel_benchmark(
             n, as, reference_sum,
             benchmarkingIters, device, local_memory_sum, "local_memory_sum",
-            work_group_size
+            work_group_size, global_work_size
         );
 
         ocl::Kernel tree_sum(sum_kernel, sum_kernel_length, "sum_gpu_5");
         run_kernel_benchmark(
             n, as, reference_sum,
             benchmarkingIters, device, tree_sum, "tree_sum",
-            work_group_size
+            work_group_size, global_work_size
         );
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,13 @@
+#include <chrono>
+#include <thread>
+
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+
+#include "cl/sum_cl.h"
 
 
 template<typename T>
@@ -14,13 +21,55 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+void run_kernel_benchmark(
+    unsigned int n, const std::vector<unsigned int> &as,
+    unsigned int reference_sum, int benchmarkingIters,
+    gpu::Device device, ocl::Kernel kernel, const std::string kernel_name
+) {
+    const unsigned int work_group_size = 64;
+    const unsigned int global_work_size = (n + work_group_size - 1) / work_group_size * work_group_size;
+
+    std::cout << std::endl;
+    std::cout << "Global work size is " << global_work_size << std::endl;
+
+    kernel.compile(false);
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            gpu::gpu_mem_32u as_gpu;
+            as_gpu.resizeN(n);
+            as_gpu.writeN(as.data(), n);
+
+            unsigned int sum = 0;
+            gpu::gpu_mem_32u sum_gpu;
+            sum_gpu.resizeN(1);
+            sum_gpu.writeN(&sum, 1);
+
+            kernel.exec(
+                gpu::WorkSize(work_group_size, global_work_size),
+                as_gpu, sum_gpu, n
+            );
+            sum_gpu.readN(&sum, 1);
+
+            EXPECT_THE_SAME(reference_sum, sum, "GPU " + kernel_name + " result should be consistent!");
+
+            t.nextLap();
+        }
+
+        std::cout << "GPU " + kernel_name + ":     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU " + kernel_name + ":     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+}
+
 
 int main(int argc, char **argv)
 {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -29,6 +78,8 @@ int main(int argc, char **argv)
     }
 
     {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
@@ -38,11 +89,15 @@ int main(int argc, char **argv)
             EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
             t.nextLap();
         }
+
+        std::cout << std::endl;
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
@@ -53,12 +108,33 @@ int main(int argc, char **argv)
             EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
             t.nextLap();
         }
+
+        std::cout << std::endl;
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        ocl::Kernel global_atomic(sum_kernel, sum_kernel_length, "sum_gpu_1");
+        run_kernel_benchmark(n, as, reference_sum, benchmarkingIters, device, global_atomic, "global_atomic");
+
+        ocl::Kernel loop_sum(sum_kernel, sum_kernel_length, "sum_gpu_2");
+        run_kernel_benchmark(n, as, reference_sum, benchmarkingIters, device, loop_sum, "loop_sum");
+
+        ocl::Kernel coalesced_loop_sum(sum_kernel, sum_kernel_length, "sum_gpu_3");
+        run_kernel_benchmark(n, as, reference_sum, benchmarkingIters, device, coalesced_loop_sum, "coalesced_loop_sum");
+
+        ocl::Kernel local_memory_sum(sum_kernel, sum_kernel_length, "sum_gpu_4");
+        run_kernel_benchmark(n, as, reference_sum, benchmarkingIters, device, local_memory_sum, "local_memory_sum");
+
+        ocl::Kernel tree_sum(sum_kernel, sum_kernel_length, "sum_gpu_5");
+        run_kernel_benchmark(n, as, reference_sum, benchmarkingIters, device, tree_sum, "tree_sum");
     }
 }


### PR DESCRIPTION
## Мандельброт

<details><summary>Локальный вывод</summary><p>

<pre>
$ build/mandelbrot
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
CPU: 1.6019+-0.026374 s
CPU: 6.24257 GFlops
    Real iterations fraction: 56.2638%
Building kernels for Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz... 
Kernels compilation done in 0.074079 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (8)
Done.

GPU: 0.271129+-0.0192889 s
GPU: 36.8828 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./mandelbrot
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.602724+-9.24608e-05 s
CPU: 16.5913 GFlops
    Real iterations fraction: 56.2638%
Building kernels for AMD EPYC 7763 64-Core Processor                ... 
Kernels compilation done in 0.03752 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (8)
Done.
GPU: 0.165941+-0.00429416 s
GPU: 60.2626 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

</p></details>

## Сумма

<details><summary>Локальный вывод</summary><p>

<pre>
$ build/sum

CPU:     0.350088+-0.00193882 s
CPU:     285.643 millions/s

CPU OMP: 0.185463+-0.000769523 s
CPU OMP: 539.192 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb

Global work size is 100000000
GPU global_atomic:     2.42905+-0.0634499 s
GPU global_atomic:     41.1684 millions/s

Global work size is 3125000
GPU loop_sum:     0.0743507+-0.00251166 s
GPU loop_sum:     1344.98 millions/s

Global work size is 3125000
GPU coalesced_loop_sum:     0.0665828+-0.00290452 s
GPU coalesced_loop_sum:     1501.89 millions/s

Global work size is 100000000
GPU local_memory_sum:     0.0578968+-0.00306586 s
GPU local_memory_sum:     1727.21 millions/s

Global work size is 100000000
GPU tree_sum:     0.288048+-0.00207402 s
GPU tree_sum:     347.164 millions/s

</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./sum

CPU:     0.034031+-0.000283748 s
CPU:     2938.5 millions/s
CPU OMP: 0.0181227+-0.000852973 s
CPU OMP: 5517.95 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Global work size is 100000000
GPU global_atomic:     1.4623+-0.0201319 s
GPU global_atomic:     68.3854 millions/s
Global work size is 3125000
GPU loop_sum:     0.0538892+-0.000654524 s
GPU loop_sum:     1855.66 millions/s
Global work size is 3125000
GPU coalesced_loop_sum:     0.0471518+-0.000165551 s
GPU coalesced_loop_sum:     2120.81 millions/s
Global work size is 100000000
GPU local_memory_sum:     0.0351612+-0.000116332 s
GPU local_memory_sum:     2844.05 millions/s
Global work size is 100000000
GPU tree_sum:     0.169434+-0.000469575 s
GPU tree_sum:     590.199 millions/s

</pre>

</p></details>

#### Анализ

При запуске на сервере GPU-версия проиграла OpenMP-версии. Скорее всего, это произошло, потому что у серверного процессора очень много потоков, и CPU-параллелизм работает достаточно хорошо. При локальном запуске такого не наблюдалось.

А так, версии с циклом работают довольно быстро, но самая быстрая -- версия с локальной памятью. Версия с деревом где-то посередине.