### PR TITLE
Task03 Лопатин Алексей HSE

### DIFF
--- a/libs/images/CMakeLists.txt
+++ b/libs/images/CMakeLists.txt
@@ -16,8 +16,9 @@ set(CMAKE_CXX_STANDARD 11)
 
 set(LIBRARIES)
 
-if(UNIX)
+if(UNIX OR APPLE)
     find_package(X11 REQUIRED)
+    include_directories(${X11_INCLUDE_DIR})
     set(LIBRARIES ${LIBRARIES} ${X11_LIBRARIES})
 endif()
 

--- a/libs/images/libimages/images.cpp
+++ b/libs/images/libimages/images.cpp
@@ -6,6 +6,8 @@
 #ifdef __unix__
     // X11-based
     #define cimg_display 1
+# elif __APPLE__
+    #define cimg_display 1
 #elif defined _WIN32
     #define cimg_display 2
 #else

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,47 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(
+    __global float* results,
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, unsigned int smoothing
+) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (j >= height || i >= width) {
+        return;
+    }
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,105 @@
-// TODO
+#define VALUES_PER_WORKITEM 64
+#define WORKGROUP_SIZE 128
+
+__kernel void atomic_sum(
+    __global const unsigned int *as,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int index = get_global_id(0);
+
+    if (index >= n) {
+        return;
+    };
+
+    atomic_add(sum, as[index]);
+}
+
+__kernel void cycle_sum(
+    __global const unsigned int *as,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int res = 0;
+    for (unsigned int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        const unsigned int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += as[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+__kernel void cycle_coalesced_sum(
+    __global const unsigned int *as,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int res = 0;
+    for (unsigned int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        const unsigned int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += as[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+__kernel void local_mem_sum(
+    __global const unsigned int *as,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = as[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+__kernel void tree_sum(
+    __global const unsigned int *as,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? as[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues / 2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
                         width, height,
                         centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
                         sizeX, sizeY,
-                        iterationsLimit, false);
+                        iterationsLimit, 0);
             results_gpu.readN(gpu_results.ptr(), width * height);
             t.nextLap();
         }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,70 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+   // Раскомментируйте это:
+
+   gpu::Context context;
+   context.init(device.device_id_opencl);
+   context.activate();
+   {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f results_gpu;
+        results_gpu.resizeN(width * height);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height),
+                        results_gpu,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit, false);
+            results_gpu.readN(gpu_results.ptr(), width * height);
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+   {
+    double errorAvg = 0.0;
+    for (int j = 0; j < height; ++j) {
+        for (int i = 0; i < width; ++i) {
+            errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+        }
+    }
+    errorAvg /= width * height;
+    std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+    if (errorAvg > 0.03) {
+        throw std::runtime_error("Too high difference between CPU and GPU results!");
+    }
+   }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,12 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+
+#include "cl/sum_cl.h"
+
+#define VALUES_PER_WORKITEM 64
 
 
 template<typename T>
@@ -59,6 +65,153 @@ int main(int argc, char **argv)
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                gpu::gpu_mem_32u as_gpu;
+                as_gpu.resizeN(n);
+                as_gpu.writeN(as.data(), n);
+
+                unsigned int sum = 0;
+                gpu::gpu_mem_32u sum_gpu;
+                sum_gpu.resizeN(1);
+                sum_gpu.writeN(&sum, 1);
+
+                ocl::Kernel atomic_sum(sum_kernel, sum_kernel_length, "atomic_sum");
+                atomic_sum.compile();
+
+                atomic_sum.exec(
+                    gpu::WorkSize(workGroupSize, global_work_size),
+                    as_gpu, sum_gpu, n
+                );
+                sum_gpu.readN(&sum, 1);
+
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (atomic) result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU (atomic):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (atomic):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                gpu::gpu_mem_32u as_gpu;
+                as_gpu.resizeN(n);
+                as_gpu.writeN(as.data(), n);
+
+                unsigned int sum = 0;
+                gpu::gpu_mem_32u sum_gpu;
+                sum_gpu.resizeN(1);
+                sum_gpu.writeN(&sum, 1);
+
+                ocl::Kernel cycle_sum(sum_kernel, sum_kernel_length, "cycle_sum");
+                cycle_sum.compile();
+
+                cycle_sum.exec(
+                    gpu::WorkSize(workGroupSize, global_work_size / VALUES_PER_WORKITEM),
+                    as_gpu, sum_gpu, n
+                );
+                sum_gpu.readN(&sum, 1);
+
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (cycle) result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU (cycle):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (cycle):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                gpu::gpu_mem_32u as_gpu;
+                as_gpu.resizeN(n);
+                as_gpu.writeN(as.data(), n);
+
+                unsigned int sum = 0;
+                gpu::gpu_mem_32u sum_gpu;
+                sum_gpu.resizeN(1);
+                sum_gpu.writeN(&sum, 1);
+
+                ocl::Kernel cycle_coalesced_sum(sum_kernel, sum_kernel_length, "cycle_coalesced_sum");
+                cycle_coalesced_sum.compile();
+
+                cycle_coalesced_sum.exec(
+                    gpu::WorkSize(workGroupSize, global_work_size / VALUES_PER_WORKITEM),
+                    as_gpu, sum_gpu, n
+                );
+                sum_gpu.readN(&sum, 1);
+
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (cycle + coalesced) result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU (cycle + coalesced):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (cycle + coalesced):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                gpu::gpu_mem_32u as_gpu;
+                as_gpu.resizeN(n);
+                as_gpu.writeN(as.data(), n);
+
+                unsigned int sum = 0;
+                gpu::gpu_mem_32u sum_gpu;
+                sum_gpu.resizeN(1);
+                sum_gpu.writeN(&sum, 1);
+
+                ocl::Kernel local_mem_sum(sum_kernel, sum_kernel_length, "local_mem_sum");
+                local_mem_sum.compile();
+
+                local_mem_sum.exec(
+                    gpu::WorkSize(workGroupSize, global_work_size),
+                    as_gpu, sum_gpu, n
+                );
+                sum_gpu.readN(&sum, 1);
+                
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (local_mem) result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU (local_mem):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (local_mem):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                gpu::gpu_mem_32u as_gpu;
+                as_gpu.resizeN(n);
+                as_gpu.writeN(as.data(), n);
+
+                unsigned int sum = 0;
+                gpu::gpu_mem_32u sum_gpu;
+                sum_gpu.resizeN(1);
+                sum_gpu.writeN(&sum, 1);
+
+                ocl::Kernel tree_sum(sum_kernel, sum_kernel_length, "tree_sum");
+                tree_sum.compile();
+
+                tree_sum.exec(
+                    gpu::WorkSize(workGroupSize, global_work_size),
+                    as_gpu, sum_gpu, n
+                );
+                sum_gpu.readN(&sum, 1);
+                
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (tree) result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU (tree):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (tree):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -74,141 +74,124 @@ int main(int argc, char **argv)
         unsigned int workGroupSize = 128;
         unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
 
+        gpu::gpu_mem_32u as_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+
+        unsigned int sum = 0;
+        gpu::gpu_mem_32u sum_gpu;
+        sum_gpu.resizeN(1);
+
         {
+            ocl::Kernel atomic_sum(sum_kernel, sum_kernel_length, "atomic_sum");
+            atomic_sum.compile();
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                gpu::gpu_mem_32u as_gpu;
-                as_gpu.resizeN(n);
-                as_gpu.writeN(as.data(), n);
-
-                unsigned int sum = 0;
-                gpu::gpu_mem_32u sum_gpu;
-                sum_gpu.resizeN(1);
+                sum = 0;
                 sum_gpu.writeN(&sum, 1);
-
-                ocl::Kernel atomic_sum(sum_kernel, sum_kernel_length, "atomic_sum");
-                atomic_sum.compile();
-
+                
+                t.restart();
                 atomic_sum.exec(
                     gpu::WorkSize(workGroupSize, global_work_size),
                     as_gpu, sum_gpu, n
                 );
-                sum_gpu.readN(&sum, 1);
-
-                EXPECT_THE_SAME(reference_sum, sum, "GPU (atomic) result should be consistent!");
                 t.nextLap();
+
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (atomic) result should be consistent!");
             }
             std::cout << "GPU (atomic):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU (atomic):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
 
         {
+            ocl::Kernel cycle_sum(sum_kernel, sum_kernel_length, "cycle_sum");
+            cycle_sum.compile();
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                gpu::gpu_mem_32u as_gpu;
-                as_gpu.resizeN(n);
-                as_gpu.writeN(as.data(), n);
-
-                unsigned int sum = 0;
-                gpu::gpu_mem_32u sum_gpu;
-                sum_gpu.resizeN(1);
+                sum = 0;
                 sum_gpu.writeN(&sum, 1);
 
-                ocl::Kernel cycle_sum(sum_kernel, sum_kernel_length, "cycle_sum");
-                cycle_sum.compile();
-
+                t.restart();
                 cycle_sum.exec(
                     gpu::WorkSize(workGroupSize, global_work_size / VALUES_PER_WORKITEM),
                     as_gpu, sum_gpu, n
                 );
-                sum_gpu.readN(&sum, 1);
-
-                EXPECT_THE_SAME(reference_sum, sum, "GPU (cycle) result should be consistent!");
                 t.nextLap();
+
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (cycle) result should be consistent!");
             }
             std::cout << "GPU (cycle):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU (cycle):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
 
         {
+            ocl::Kernel cycle_coalesced_sum(sum_kernel, sum_kernel_length, "cycle_coalesced_sum");
+            cycle_coalesced_sum.compile();
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                gpu::gpu_mem_32u as_gpu;
-                as_gpu.resizeN(n);
-                as_gpu.writeN(as.data(), n);
-
-                unsigned int sum = 0;
-                gpu::gpu_mem_32u sum_gpu;
-                sum_gpu.resizeN(1);
+                sum = 0;
                 sum_gpu.writeN(&sum, 1);
 
-                ocl::Kernel cycle_coalesced_sum(sum_kernel, sum_kernel_length, "cycle_coalesced_sum");
-                cycle_coalesced_sum.compile();
-
+                t.restart();
                 cycle_coalesced_sum.exec(
                     gpu::WorkSize(workGroupSize, global_work_size / VALUES_PER_WORKITEM),
                     as_gpu, sum_gpu, n
                 );
-                sum_gpu.readN(&sum, 1);
-
-                EXPECT_THE_SAME(reference_sum, sum, "GPU (cycle + coalesced) result should be consistent!");
                 t.nextLap();
+
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (cycle + coalesced) result should be consistent!");
             }
             std::cout << "GPU (cycle + coalesced):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU (cycle + coalesced):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
 
         {
+            ocl::Kernel local_mem_sum(sum_kernel, sum_kernel_length, "local_mem_sum");
+            local_mem_sum.compile();
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                gpu::gpu_mem_32u as_gpu;
-                as_gpu.resizeN(n);
-                as_gpu.writeN(as.data(), n);
-
-                unsigned int sum = 0;
-                gpu::gpu_mem_32u sum_gpu;
-                sum_gpu.resizeN(1);
+                sum = 0;
                 sum_gpu.writeN(&sum, 1);
 
-                ocl::Kernel local_mem_sum(sum_kernel, sum_kernel_length, "local_mem_sum");
-                local_mem_sum.compile();
-
+                t.restart();
                 local_mem_sum.exec(
                     gpu::WorkSize(workGroupSize, global_work_size),
                     as_gpu, sum_gpu, n
                 );
-                sum_gpu.readN(&sum, 1);
-                
-                EXPECT_THE_SAME(reference_sum, sum, "GPU (local_mem) result should be consistent!");
                 t.nextLap();
+
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (local_mem) result should be consistent!");
             }
             std::cout << "GPU (local_mem):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU (local_mem):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
 
         {
+            ocl::Kernel tree_sum(sum_kernel, sum_kernel_length, "tree_sum");
+            tree_sum.compile();
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                gpu::gpu_mem_32u as_gpu;
-                as_gpu.resizeN(n);
-                as_gpu.writeN(as.data(), n);
-
-                unsigned int sum = 0;
-                gpu::gpu_mem_32u sum_gpu;
-                sum_gpu.resizeN(1);
+                sum = 0;
                 sum_gpu.writeN(&sum, 1);
-
-                ocl::Kernel tree_sum(sum_kernel, sum_kernel_length, "tree_sum");
-                tree_sum.compile();
-
+                
+                t.restart();
                 tree_sum.exec(
                     gpu::WorkSize(workGroupSize, global_work_size),
                     as_gpu, sum_gpu, n
                 );
-                sum_gpu.readN(&sum, 1);
-                
-                EXPECT_THE_SAME(reference_sum, sum, "GPU (tree) result should be consistent!");
                 t.nextLap();
+
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU (tree) result should be consistent!");
             }
             std::cout << "GPU (tree):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU (tree):     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;


### PR DESCRIPTION
## mandelbrot
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./mandelbrot
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
CPU: 4.0721+-0.00862937 s
CPU: 2.45573 GFlops
    Real iterations fraction: 56.2657%
GPU: 0.0074115+-0.000379725 s
GPU: 1349.25 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.604094+-0.00315337 s
CPU: 16.5537 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.162827+-0.000825261 s
GPU: 61.4149 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.943129%
</pre>

</p></details>

## sum
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./sum
CPU:     0.1668+-0.00368793 s
CPU:     599.519 millions/s
CPU OMP: 0.23085+-0.0025537 s
CPU OMP: 433.182 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU (atomic):     0.00748417+-0.000168812 s
GPU (atomic):     13361.5 millions/s
GPU (cycle):     0.0132677+-0.000341104 s
GPU (cycle):     7537.12 millions/s
GPU (cycle + coalesced):     0.00481417+-0.000588097 s
GPU (cycle + coalesced):     20772 millions/s
GPU (local_mem):     0.00479833+-0.00073034 s
GPU (local_mem):     20840.6 millions/s
GPU (tree):     0.006941+-0.000317999 s
GPU (tree):     14407.1 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
CPU:     0.0320427+-2.38723e-05 s
CPU:     3120.84 millions/s
CPU OMP: 0.0181488+-0.000497397 s
CPU OMP: 5510 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU (atomic):     1.42512+-0.00092875 s
GPU (atomic):     70.1694 millions/s
GPU (cycle):     0.0274973+-3.46875e-05 s
GPU (cycle):     3636.72 millions/s
GPU (cycle + coalesced):     0.0244463+-2.76023e-05 s
GPU (cycle + coalesced):     4090.59 millions/s
GPU (local_mem):     0.0349868+-4.37128e-05 s
GPU (local_mem):     2858.22 millions/s
GPU (tree):     0.164037+-0.000577624 s
GPU (tree):     609.619 millions/s
</pre>

</p></details>

К сожалению, не удалось завести OpenMP на macos и увидеть легкий прирост производительности и программа работала на одном ядре. Локально выиграл вариант с деревом, однако, при увеличении `VALUES_PER_WORKITEM` до 128 выигрывает cycle + coalesced вариант, что связано с размером кэш линии на моем процессоре. Что интересно, даже atomic вариант локально приносит до 3х-кратного прироста производительности, вероятно из-за оптимизаций вроде локального кэша, как говорилось на лекции