### PR TITLE
Task03 Алексей Казаков ITMO

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,49 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(
+    __global float* results,
+    unsigned int width,
+    unsigned int height,
+    float fromX,
+    float fromY,
+    float sizeX,
+    float sizeY,
+    unsigned int iters
+) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const size_t index = get_global_id(0);
+    if (index > width * height) {
+        return;
+    }
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    const unsigned int j = index / width;
+    const unsigned int i = index % width;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        const float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = 1.0f * iter / iters;
+
+    results[index] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,107 @@
-// TODO
+__kernel void sum_atomic(
+    __global const unsigned int* arr,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const size_t index = get_global_id(0);
+    if (index >= n) {
+        return;
+    }
+    atomic_add(sum, arr[index]);
+}
+
+#define WORKITEM_SIZE 64
+
+__kernel void sum_loop_not_coalesced(
+    __global const unsigned int* arr,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int start = get_global_id(0) * WORKITEM_SIZE;
+    const unsigned int end = min(start + WORKITEM_SIZE, n);
+
+    unsigned int partial_sum = 0;
+    for (unsigned int i = start; i < end; ++i) {
+        partial_sum += arr[i];
+    }
+
+    atomic_add(sum, partial_sum);
+}
+
+__kernel void sum_loop_coalesced(
+    __global const unsigned int* arr,
+    __global unsigned int* sum,
+    unsigned int n
+) {
+    const unsigned int group_size = get_local_size(0);
+    const unsigned int start = get_group_id(0) * group_size * WORKITEM_SIZE + get_local_id(0);
+    const unsigned int end = min(start + group_size * WORKITEM_SIZE, n);
+
+    unsigned int partial_sum = 0;
+    for (unsigned int i = start; i < end; i += group_size) {
+        partial_sum += arr[i];
+    }
+
+    atomic_add(sum, partial_sum);
+}
+
+#define WORKGROUP_SIZE 128
+
+__kernel void sum_main_thread(
+    __global const unsigned int *arr,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    __local unsigned int local_arr[WORKGROUP_SIZE];
+
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    if (gid < n) {
+        local_arr[lid] = arr[gid];
+    } else {
+        local_arr[lid] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int partial_sum = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
+            partial_sum += local_arr[i];
+        }
+        atomic_add(sum, partial_sum);
+    }
+}
+
+__kernel void sum_tree(
+    __global const unsigned int *arr,
+    __global unsigned int *sum,
+    unsigned int n
+) {
+    __local unsigned int local_arr[WORKGROUP_SIZE];
+
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    if (gid < n) {
+        local_arr[lid] = arr[gid];
+    } else {
+        local_arr[lid] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (unsigned int k = WORKGROUP_SIZE; k > 1; k /= 2) {
+        if (lid * 2 < k) {
+            int a = local_arr[lid];
+            int b = local_arr[lid + k / 2];
+            local_arr[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, local_arr[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,82 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+
+       // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+       // результат должен оказаться в gpu_results
+
+        const unsigned int n = width * height;
+
+        const unsigned int work_group_size = 128;
+        const unsigned int global_work_size = (n + work_group_size - 1) / work_group_size * work_group_size;
+
+        gpu::gpu_mem_32f buffer_gpu;
+        buffer_gpu.resizeN(n);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(
+                gpu::WorkSize(work_group_size, global_work_size),
+                buffer_gpu,
+                width,
+                height,
+                centralX - sizeX / 2.0f,
+                centralY - sizeY / 2.0f,
+                sizeX,
+                sizeY,
+                iterationsLimit
+            );
+            t.nextLap();
+        }
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        buffer_gpu.readN(gpu_results.ptr(), n);
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -2,6 +2,9 @@
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
 
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+#include "cl/sum_cl.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -57,8 +60,40 @@ int main(int argc, char **argv)
         std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
-    {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
-    }
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    const auto run = [&](const std::string& kernel_name, gpu::WorkSize work_size){
+        gpu::gpu_mem_32u as_gpu;
+        gpu::gpu_mem_32u sum_gpu;
+
+        as_gpu.resizeN(as.size());
+        sum_gpu.resizeN(1);
+
+        as_gpu.writeN(as.data(), as.size());
+
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+        kernel.compile();
+
+        const std::string platform_name = "GPU " + kernel_name;
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sum = 0;
+            sum_gpu.writeN(&sum, 1);
+            kernel.exec(work_size, as_gpu, sum_gpu, n);
+            sum_gpu.readN(&sum, 1);
+            EXPECT_THE_SAME(reference_sum, sum, platform_name + " result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << platform_name << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << platform_name << ": " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    };
+
+    run("sum_atomic", gpu::WorkSize(128, n));
+    run("sum_loop_not_coalesced", gpu::WorkSize(128, n / 64));
+    run("sum_loop_coalesced", gpu::WorkSize(128, n / 64));
+    run("sum_main_thread", gpu::WorkSize(128, n));
+    run("sum_tree", gpu::WorkSize(128, n));
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
mandelbrot:
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16084 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6433 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
CPU: 2.99267+-0.0201301 s
CPU: 3.3415 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.00266667+-0.000471405 s
GPU: 3750 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%

sum:
CPU:     0.0995+-0.00160728 s
CPU:     1005.03 millions/s
CPU OMP: 0.099+-0.00057735 s
CPU OMP: 1010.1 millions/s
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16084 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6433 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
GPU sum_atomic: 0.003+-4.1159e-11 s
GPU sum_atomic: 33333.3 millions/s
GPU sum_loop_not_coalesced: 0.00266667+-0.000471405 s
GPU sum_loop_not_coalesced: 37500 millions/s
GPU sum_loop_coalesced: 0.0015+-0.0005 s
GPU sum_loop_coalesced: 66666.7 millions/s
GPU sum_main_thread: 0.002+-0 s
GPU sum_main_thread: 50000 millions/s
GPU sum_tree: 0.00366667+-0.000471405 s
GPU sum_tree: 27272.7 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
mandelbrot:
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.603396+-0.00113425 s
CPU: 16.5729 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.157226+-0.000410134 s
GPU: 63.6026 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%

sum:
CPU:     0.0323192+-0.000136642 s
CPU:     3094.14 millions/s
CPU OMP: 0.0181663+-0.000204005 s
CPU OMP: 5504.69 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU sum_atomic: 1.46878+-0.000824101 s
GPU sum_atomic: 68.0836 millions/s
GPU sum_loop_not_coalesced: 0.0285463+-5.06052e-05 s
GPU sum_loop_not_coalesced: 3503.08 millions/s
GPU sum_loop_coalesced: 0.0253798+-2.55566e-05 s
GPU sum_loop_coalesced: 3940.14 millions/s
GPU sum_main_thread: 0.0404185+-5.26205e-05 s
GPU sum_main_thread: 2474.11 millions/s
GPU sum_tree: 0.214689+-0.000536056 s
GPU sum_tree: 465.791 millions/s
</pre>

</p></details>

Наиболее быстро на моем железе выполняется версия с coalesced циклом, что, думаю, вполне ожидаемо, т. к. в данной версии потоки заняты работой, и обращения к памяти происходят кеш-френдли образом. Суммирование с деревом же выполнялось на удивление медленно, даже хуже простой атомарной версии. Думаю, дело в большом количестве дополнительной логики, а так же в умном драйвере