### PR TITLE
Task03 Барсуков Илья ITMO

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -1,13 +1,45 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+    #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+// arguments got from mandelbrotCPU example
+__kernel void mandelbrot(__global float* results,
+                         unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters, int smoothing) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    float threshold = 256.;
+    float threshold2 = threshold * threshold;
+
+    int iter = 0;
+    for (;iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.f);
+    }
+    result = 1.f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,89 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void sum_global_atomic(__global const unsigned* arr, unsigned size, __global unsigned* result) {
+    unsigned id = get_global_id(0);
+
+    if (id < size) {
+        atomic_add(result, arr[id]);
+    }
+}
+__kernel void sum_loop(__global const unsigned* arr, unsigned size, __global unsigned* result) {
+#define VALS_PER_WORKITEM 64
+    unsigned id = get_global_id(0);
+
+    unsigned res = 0;
+    for (int i = 0; i < VALS_PER_WORKITEM; ++i) {
+        int idx = id * VALS_PER_WORKITEM + i;
+        if (idx < size) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(result, res);
+#undef VALS_PER_WORKITEM
+}
+__kernel void sum_loop_coalesced(__global const unsigned* arr, unsigned size, __global unsigned* result) {
+#define VALS_PER_WORKITEM 64
+    const unsigned localId = get_local_id(0);
+    const unsigned groupId = get_group_id(0);
+    const unsigned localSize = get_local_size(0);
+
+    unsigned res = 0;
+    for (int i = 0; i < VALS_PER_WORKITEM; ++i) {
+        // possible overflow
+        unsigned idx = groupId * localSize * VALS_PER_WORKITEM + i * localSize + localId;
+        if (idx < size) {
+            res += arr[idx];
+        }
+    }
+    atomic_add(result, res);
+#undef VALS_PER_WORKITEM
+}
+__kernel void sum_local_mem(__global const unsigned* arr, unsigned size, __global unsigned* result) {
+#define WORKGROUP_SIZE 128
+    unsigned globalId = get_global_id(0);
+    unsigned localId = get_local_id(0);
+
+    __local unsigned localArr[WORKGROUP_SIZE];
+    localArr[localId] = globalId < size ? arr[globalId] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (localId == 0) {
+        unsigned partialSum = 0;
+        for (unsigned i = 0; i < WORKGROUP_SIZE; ++i) {
+            partialSum += localArr[i];
+        }
+        atomic_add(result, partialSum);
+    }
+#undef WORKGROUP_SIZE
+}
+__kernel void sum_tree(__global const unsigned* arr, unsigned size, __global unsigned* result) {
+#define WORKGROUP_SIZE 128
+    unsigned globalId = get_global_id(0);
+    unsigned localId = get_local_id(0);
+
+    __local unsigned localArr[WORKGROUP_SIZE];
+    localArr[localId] = globalId < size ? arr[globalId] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (unsigned k = WORKGROUP_SIZE; k > 1; k /= 2) {
+        if (localId * 2 < k) {
+            int a = localArr[localId];
+            int b = localArr[localId + k / 2];
+            localArr[localId] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (localId == 0) {
+        atomic_add(result, localArr[0]);
+    }
+
+#undef WORKGROUP_SIZE
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,45 +106,60 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        unsigned amount = width * height;
+
+        gpu::gpu_mem_32f gpuRes;
+        gpuRes.resizeN(amount);
+
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height), gpuRes, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
+        }
+
+
+        gpuRes.readN(gpu_results.ptr(), amount);
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
+//    bool useGPU = true;
 //    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,10 @@
+#include "libgpu/context.h"
+#include "libgpu/shared_device_buffer.h"
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
+
+#include "cl/sum_cl.h"
 
 
 template<typename T>
@@ -13,6 +17,29 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
+
+// I want std::string_view..
+void runKernel(int benchmarkingIters, unsigned int reference_sum, unsigned int n, std::vector<unsigned int> &as, gpu::WorkSize size, const char* name) {
+    gpu::gpu_mem_32u gpuAS, gpuSum;
+    gpuAS.resizeN(n);
+    gpuSum.resizeN(1);
+    gpuAS.writeN(as.data(), n);
+    ocl::Kernel kernel(sum_kernel, sum_kernel_length, name);
+    kernel.compile();
+
+    timer t;
+    for (int i = 0; i < benchmarkingIters; ++i) {
+        unsigned sum = 0;
+        gpuSum.writeN(&sum, 1);
+        kernel.exec(size, gpuAS, n, gpuSum);
+        gpuSum.readN(&sum, 1);
+        t.nextLap();
+        EXPECT_THE_SAME(reference_sum, sum, "OpenCL Results must be consistent");
+    }
+
+    std::cout << "GPU kernel '" << name << "' : " << t.lapAvg() << "+-" << t.lapStd() << "s\n"
+    << "  Time: " << (n / 1000. / 1000.) / t.lapAvg() << " millions/s\n";
+}
 
 
 int main(int argc, char **argv)
@@ -28,37 +55,49 @@ int main(int argc, char **argv)
         reference_sum += as[i];
     }
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            unsigned int sum = 0;
-            for (int i = 0; i < n; ++i) {
-                sum += as[i];
-            }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
-            t.nextLap();
-        }
-        std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
-    }
+//    {
+//        timer t;
+//        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+//            unsigned int sum = 0;
+//            for (int i = 0; i < n; ++i) {
+//                sum += as[i];
+//            }
+//            EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
+//            t.nextLap();
+//        }
+//        std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+//        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+//    }
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
-            for (int i = 0; i < n; ++i) {
-                sum += as[i];
-            }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
-            t.nextLap();
-        }
-        std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
-    }
+//    {
+//        timer t;
+//        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+//            unsigned int sum = 0;
+//            #pragma omp parallel for reduction(+:sum)
+//            for (int i = 0; i < n; ++i) {
+//                sum += as[i];
+//            }
+//            EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
+//            t.nextLap();
+//        }
+//        std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+//        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+//    }
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+         gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+         gpu::Context context;
+         context.init(device.device_id_opencl);
+         context.activate();
+
+         {
+             runKernel(benchmarkingIters, reference_sum, n, as, gpu::WorkSize(128, n), "sum_global_atomic");
+             runKernel(benchmarkingIters, reference_sum, n, as, gpu::WorkSize(128, n / 64), "sum_loop");
+             runKernel(benchmarkingIters, reference_sum, n, as, gpu::WorkSize(128, n / 64), "sum_loop_coalesced");
+             runKernel(benchmarkingIters, reference_sum, n, as, gpu::WorkSize(128, n), "sum_local_mem");
+             runKernel(benchmarkingIters, reference_sum, n, as, gpu::WorkSize(128, n), "sum_tree");
+         }
     }
 }
+


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 7095 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Total memory: 4095 Mb
Using device #0: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 7095 Mb
CPU: 0.289833+-0.007946 s
CPU: 34.5026 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%

---------------------------------------------------------------------------------

OpenCL devices:
  Device #0: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 7095 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Total memory: 4095 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Total memory: 4095 Mb
CPU: 0.296833+-0.0065426 s
CPU: 33.6889 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%

===================================================================================

OpenCL devices:
  Device #0: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 7095 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Total memory: 4095 Mb
Using device #0: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 7095 Mb
GPU kernel 'sum_global_atomic' : 0.008+-0s
  Time: 12500 millions/s
GPU kernel 'sum_loop' : 0.0141667+-0.000372678s
  Time: 7058.82 millions/s
GPU kernel 'sum_loop_coalesced' : 0.008+-0s
  Time: 12500 millions/s
GPU kernel 'sum_local_mem' : 0.00866667+-0.000471405s
  Time: 11538.5 millions/s
GPU kernel 'sum_tree' : 0.0095+-0.0005s
  Time: 10526.3 millions/s

-----------------------------------------------------------------------------------

OpenCL devices:
  Device #0: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 7095 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Total memory: 4095 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Total memory: 4095 Mb
GPU kernel 'sum_global_atomic' : 0.004+-0s
  Time: 25000 millions/s
GPU kernel 'sum_loop' : 0.006+-8.23181e-11s
  Time: 16666.7 millions/s
GPU kernel 'sum_loop_coalesced' : 0.00233333+-0.000471405s
  Time: 42857.1 millions/s
GPU kernel 'sum_local_mem' : 0.00316667+-0.000372678s
  Time: 31578.9 millions/s
GPU kernel 'sum_tree' : 0.00633333+-0.000471405s
  Time: 15789.5 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>

OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.604157+-0.00142964 s
CPU: 16.552 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.943129%
===============================================================================
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU kernel 'sum_global_atomic' : 1.5738+-0.000621446s
  Time: 63.5405 millions/s
GPU kernel 'sum_loop' : 0.0301477+-3.31746e-05s
  Time: 3317.01 millions/s
GPU kernel 'sum_loop_coalesced' : 0.0255482+-5.48191e-05s
  Time: 3914.18 millions/s
GPU kernel 'sum_local_mem' : 0.041142+-5.70175e-05s
  Time: 2430.61 millions/s
GPU kernel 'sum_tree' : 0.164329+-0.000226998s
  Time: 608.537 millions/s

</pre>

</p></details>

Довольно забавно, `coalesced` код работает везде быстрее, чем другие варианты. Также довольно интересно, что на Intel OpenCL даже глобальный atomic отрабатывает нормально. Видимо, слишком умный драйвер/разности архитектуры?
Я также попытался поиграться с настройками энергопотребления, но это ничего не изменило в результате. `coalesced` вариант цикла всё равно был лучше всего