### PR TITLE
Task04 Леонид Тернопол SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,5 +1,7 @@
 #ifdef __CLION_IDE__
-    #include <libgpu/opencl/cl/clion_defines.cl>
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 
@@ -7,21 +9,100 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
-{
-    // TODO
+__kernel void matrix_multiplication_naive(
+        __global const float *as,
+        __global const float *bs,
+        __global float *cs,
+        unsigned int m,
+        unsigned int k,
+        unsigned int n
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= m || j >= n) return;
+
+    float res = 0.0f;
+    for (int l = 0; l < k; ++l) {
+        res += as[j * k + l] * bs[l * n + i];
+    }
+    cs[j * n + i] = res;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
-{
-    // TODO
+__kernel void matrix_multiplication_local(
+        __global const float *as,
+        __global const float *bs,
+        __global float *cs,
+        unsigned int m,
+        unsigned int k,
+        unsigned int n
+) {
+    unsigned int wi = get_global_id(0);
+    unsigned int wj = get_global_id(1);
+    unsigned int i = get_local_id(0);
+    unsigned int j = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float res = 0.0f;
+    for (int tileOff = 0; tileOff < k; tileOff += TILE_SIZE) {
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        tileA[j][i] = wi >= n || wj >= m || tileOff + i >= k ? 0 : as[(tileOff + i) + wj * k];
+        tileB[j][i] = wi >= n || wj >= m || tileOff + j >= k ? 0 : bs[wi + (tileOff + j) * k];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int l = 0; l < TILE_SIZE; ++l) {
+            res += tileA[j][l] * tileB[l][i];
+        }
+    }
+    if (wi < n && wj < m) {
+        cs[wj * n + wi] = res;
+    }
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
-{
-    // TODO
+__kernel void matrix_multiplication_local_wpt(
+        __global const float *as,
+        __global const float *bs,
+        __global float *cs,
+        unsigned int m,
+        unsigned int k,
+        unsigned int n
+) {
+    unsigned int i = get_local_id(0);
+    unsigned int j = get_local_id(1) * WORK_PER_THREAD;
+    unsigned int wi = get_group_id(0) * TILE_SIZE + i;
+    unsigned int wj = get_group_id(1) * TILE_SIZE + j;
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float res[WORK_PER_THREAD] = {};
+    for (int dj = 0; dj < WORK_PER_THREAD; ++dj) res[dj] = 0;
+
+    for (int tileOff = 0; tileOff < k; tileOff += TILE_SIZE) {
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        for (int dj = 0; dj < WORK_PER_THREAD; ++dj) {
+            tileA[j + dj][i] = wi >= n || wj >= m || tileOff + i >= k ? 0 : as[(tileOff + i) + (wj + dj) * k];
+            tileB[j + dj][i] = wi >= n || wj >= m || tileOff + j >= k ? 0 : bs[wi + (tileOff + j + dj) * n];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int l = 0; l < TILE_SIZE; ++l) {
+            for (int dj = 0; dj < WORK_PER_THREAD; ++dj) {
+                res[dj] += tileA[j + dj][l] * tileB[l][i];
+            }
+        }
+    }
+    for (int dj = 0; dj < WORK_PER_THREAD; ++dj) {
+        if (wi < n && wj + dj < m) {
+            cs[(wj + dj) * n + wi] = res[dj];
+        }
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,60 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
-{
-    // TODO
+__kernel void matrix_transpose_naive(__global const float *as, __global float *as_t, unsigned int m, unsigned int k) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= k || j >= m) return;
+
+    as_t[i * m + j] = as[j * k + i];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_bad_banks(__global const float *as, __global float *as_t, unsigned int m, unsigned int k) {
+    unsigned int i = LINES_PER_GROUP0 * get_local_id(0);
+    unsigned int j = LINES_PER_GROUP1 * get_local_id(1);
+    unsigned int wi = TILE_SIZE * get_group_id(0) + i;
+    unsigned int wj = TILE_SIZE * get_group_id(1) + j;
+
+    __local float buf[TILE_SIZE][TILE_SIZE];
+
+    for (int dj = 0; dj < LINES_PER_GROUP1; ++dj) {
+        for (int di = 0; di < LINES_PER_GROUP0; ++di) {
+            buf[i + di][j + dj] = wi + di >= k || wj + dj >= m ? 0 : as[(wj + dj) * k + wi + di];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (wi >= k || wj >= m) return;
+    for (int dj = 0; dj < LINES_PER_GROUP1; ++dj) {
+        for (int di = 0; di < LINES_PER_GROUP0; ++di) {
+            as_t[(wi - i + j + dj) * m + (wj - j + i + di)] = buf[j + dj][i + di];
+        }
+    }
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_good_banks(__global const float *as, __global float *as_t, unsigned int m, unsigned int k) {
+    unsigned int i = get_local_id(0);
+    unsigned int j = get_local_id(1);
+    unsigned int wi = TILE_SIZE * get_group_id(0) + i;
+    unsigned int wj = TILE_SIZE * get_group_id(1) + j;
+
+    __local float buf[TILE_SIZE][TILE_SIZE + 1];
+
+    const int stride_j = TILE_SIZE / LINES_PER_GROUP1;
+    const int stride_i = TILE_SIZE / LINES_PER_GROUP0;
+
+    for (int dj = 0; dj < LINES_PER_GROUP1; ++dj) {
+        for (int di = 0; di < LINES_PER_GROUP0; ++di) {
+            buf[i + di * stride_i][j + dj * stride_j] = wi + di * stride_i >= k || wj + dj * stride_j >= m ? 0 : as[(wj + dj * stride_j) * k + wi + di * stride_i];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (wi >= k || wj >= m) return;
+    for (int dj = 0; dj < LINES_PER_GROUP1; ++dj) {
+        for (int di = 0; di < LINES_PER_GROUP0; ++di) {
+            as_t[(wi - i + j + dj * stride_j) * m + (wj - j + i + di * stride_i)] = buf[j + dj * stride_j][i + di * stride_i];
+        }
+    }
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -143,9 +140,6 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
 
-    // TODO uncomment
-    return 0;
-
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
@@ -158,6 +152,11 @@ int main(int argc, char **argv)
         for (unsigned int wpt : {2, 4, 8, 16})
             if (wpt <= tile_size)
                 runTest(makeLocalWPTConfig(tile_size, wpt), as.data(), bs.data(), cs_cpu_reference.data());
+
+    // local выигрывает у наивной реализации в 2 раза, а wpt работает ещё чуть-чуть быстрее.
+    // В wpt при фиксированном ts Лучший результат выдаёт вариант c `ts * (ts / wps) = 32`,
+    // то есть когда вся рабочая группа умещается на 1 варп. Вероятно, в этом случае драйвер избавляется от барьеров,
+    // при меньших значениях недоиспользует потоки варпа, а при больших теряет производительность на синхронизации
 
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./matrix_transpose 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 7840HS with Radeon 780M Graphics   . Intel(R) Corporation. Total memory: 28356 Mb
  Device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
Using device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00516667+-0.000372678 s
    GPU: 3247.2 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.004+-0 s
    GPU: 4194.3 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.004+-0 s
    GPU: 4194.3 millions/s

Process finished with exit code 0
</pre>

<pre>
$ ./matrix_multiplication 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 7840HS with Radeon 780M Graphics   . Intel(R) Corporation. Total memory: 28356 Mb
  Device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
Using device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14457/14537 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 5.941+-0 s
CPU: 0.336644 GFlops
[naive, ts=4]
    GPU: 0.0498333+-0.000687184 s
    GPU: 40.1338 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.0266667+-0.00221108 s
    GPU: 75 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.026+-0.00223607 s
    GPU: 76.9231 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.0291667+-0.00186339 s
    GPU: 68.5714 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.0126667+-0.00169967 s
    GPU: 157.895 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.0105+-0.00206155 s
    GPU: 190.476 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.044+-0.00057735 s
    GPU: 45.4545 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.0796667+-0.000745356 s
    GPU: 25.1046 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.012+-0.00258199 s
    GPU: 166.667 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.0163333+-0.0020548 s
    GPU: 122.449 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.0236667+-0.00213437 s
    GPU: 84.507 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.012+-0.00270801 s
    GPU: 166.667 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.00916667+-0.00186339 s
    GPU: 218.182 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.0105+-0.00206155 s
    GPU: 190.476 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.012+-0.00216025 s
    GPU: 166.667 GFlops
    Average difference: 0.000196008%

Process finished with exit code 0
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.015197+-9.17267e-05 s
    GPU: 1103.98 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0306971+-0.000314199 s
    GPU: 546.54 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0226928+-0.000173833 s
    GPU: 739.319 millions/s
</pre>

<pre>
Run ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.28414+-0 s
CPU: 0.318261 GFlops
[naive, ts=4]
    GPU: 0.257223+-0.00100428 s
    GPU: 7.77535 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.227822+-0.0050051 s
    GPU: 8.7788 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.261087+-0.00799969 s
    GPU: 7.66029 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.580565+-0.0022617 s
    GPU: 3.44492 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.0624967+-0.000227411 s
    GPU: 32.0017 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0477537+-0.000180429 s
    GPU: 41.8816 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.505649+-0.000616192 s
    GPU: 3.95531 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.46069+-0.0012857 s
    GPU: 4.34132 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.333182+-0.00112308 s
    GPU: 6.00272 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.27438+-0.00186826 s
    GPU: 7.28917 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.258156+-0.00264122 s
    GPU: 7.74727 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.215825+-0.000467685 s
    GPU: 9.26677 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.185104+-0.000570098 s
    GPU: 10.8047 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0480207+-0.000314386 s
    GPU: 41.6487 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.050712+-0.000800354 s
    GPU: 39.4384 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>
