### PR TITLE
Task04 Василий Можаев SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -74,8 +74,8 @@ __kernel void matrix_multiplication_local_wpt(
 {
     int lid0 = get_local_id(0) * WORK_PER_THREAD;
     int lid1 = get_local_id(1);
-    int gid0 = get_group_id(0) * TILE_SIZE + lid0;
-    int gid1 = get_group_id(1) * TILE_SIZE + lid1;
+    int gid0 = get_global_id(0) * WORK_PER_THREAD;
+    int gid1 = get_global_id(1);
 
     __local float abuf[TILE_SIZE][TILE_SIZE];
     __local float bbuf[TILE_SIZE][TILE_SIZE];

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,105 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(
+    __global const float* as,
+    __global const float* bs,
+    __global float* cs,
+    int M,
+    int K,
+    int N)
 {
-    // TODO
+    int gid0 = get_global_id(0);
+    int gid1 = get_global_id(1);
+
+    float res = 0;
+    for (int k = 0; k < K; ++k) {
+        res += as[gid0 * K + k] * bs[k * N + gid1];
+    }
+
+    cs[gid0 * N + gid1] = res;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(
+    __global const float* as,
+    __global const float* bs,
+    __global float* cs,
+    int M,
+    int K,
+    int N)
 {
-    // TODO
+    int gid0 = get_global_id(0);
+    int gid1 = get_global_id(1);
+    int lid0 = get_local_id(0);
+    int lid1 = get_local_id(1);
+
+    __local float abuf[TILE_SIZE][TILE_SIZE];
+    __local float bbuf[TILE_SIZE][TILE_SIZE];
+    
+    float res = 0;
+    for (int i = 0; i < K; i += TILE_SIZE) {
+        // load tiles to buffers
+        abuf[lid0][lid1] = as[gid0 * K + (i + lid1)];
+        bbuf[lid0][lid1] = bs[(i + lid0) * N + gid1];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // accumulate results into res
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            res += abuf[lid0][k] * bbuf[k][lid1];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    cs[gid0 * N + gid1] = res;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(
+    __global const float* as,
+    __global const float* bs,
+    __global float* cs,
+    int M,
+    int K,
+    int N)
 {
-    // TODO
+    int lid0 = get_local_id(0) * WORK_PER_THREAD;
+    int lid1 = get_local_id(1);
+    int gid0 = get_group_id(0) * TILE_SIZE + lid0;
+    int gid1 = get_group_id(1) * TILE_SIZE + lid1;
+
+    __local float abuf[TILE_SIZE][TILE_SIZE];
+    __local float bbuf[TILE_SIZE][TILE_SIZE];
+    
+    float res[WORK_PER_THREAD];
+    for (int j = 0; j < WORK_PER_THREAD; ++j) {
+        res[j] = 0;
+    }
+
+    for (int i = 0; i < K; i += TILE_SIZE) {
+        // load tiles to buffers
+        for (int j = 0; j < WORK_PER_THREAD; ++j) {
+            abuf[lid0 + j][lid1] = as[(gid0 + j) * K + (i + lid1)];
+            bbuf[lid0 + j][lid1] = bs[(i + lid0 + j) * N + gid1];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // accumulate results into res
+        for (int j = 0; j < WORK_PER_THREAD; ++j) {
+            for (int k = 0; k < TILE_SIZE; ++k) {
+                res[j] += abuf[lid0 + j][k] * bbuf[k][lid1];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int j = 0; j < WORK_PER_THREAD; ++j) {
+        cs[(gid0 + j) * N + gid1] = res[j];
+    }
 }
 #endif

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -88,8 +88,8 @@ __kernel void matrix_multiplication_local_wpt(
     for (int i = 0; i < K; i += TILE_SIZE) {
         // load tiles to buffers
         for (int j = 0; j < WORK_PER_THREAD; ++j) {
-            abuf[lid0 + j][lid1] = as[(gid0 + j) * K + (i + lid1)];
-            bbuf[lid0 + j][lid1] = bs[(i + lid0 + j) * N + gid1];
+            abuf[lid1][lid0 + j] = as[gid1 * K + (i + lid0 + j)];
+            bbuf[lid1][lid0 + j] = bs[(i + lid1) * N + gid0 + j];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -97,7 +97,7 @@ __kernel void matrix_multiplication_local_wpt(
         // accumulate results into res
         for (int j = 0; j < WORK_PER_THREAD; ++j) {
             for (int k = 0; k < TILE_SIZE; ++k) {
-                res[j] += abuf[lid0 + j][k] * bbuf[k][lid1];
+                res[j] += abuf[lid1][k] * bbuf[k][lid0 + j];
             }
         }
 
@@ -105,7 +105,7 @@ __kernel void matrix_multiplication_local_wpt(
     }
 
     for (int j = 0; j < WORK_PER_THREAD; ++j) {
-        cs[gid1 + (gid0 + j) * N] = res[j];
+        cs[(gid0 + j) + gid1 * N] = res[j];
     }
 }
 #endif

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -88,8 +88,8 @@ __kernel void matrix_multiplication_local_wpt(
     for (int i = 0; i < K; i += TILE_SIZE) {
         // load tiles to buffers
         for (int j = 0; j < WORK_PER_THREAD; ++j) {
-            abuf[lid1][lid0 + j] = as[gid1 * K + (i + lid0 + j)];
-            bbuf[lid1][lid0 + j] = bs[(i + lid1) * N + gid0 + j];
+            abuf[lid0 + j][lid1] = as[(gid0 + j) * K + (i + lid1)];
+            bbuf[lid0 + j][lid1] = bs[(i + lid0 + j) * N + gid1];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -97,7 +97,7 @@ __kernel void matrix_multiplication_local_wpt(
         // accumulate results into res
         for (int j = 0; j < WORK_PER_THREAD; ++j) {
             for (int k = 0; k < TILE_SIZE; ++k) {
-                res[j] += abuf[lid1][k] * bbuf[k][lid0 + j];
+                res[j] += abuf[lid0 + j][k] * bbuf[k][lid1];
             }
         }
 
@@ -105,7 +105,7 @@ __kernel void matrix_multiplication_local_wpt(
     }
 
     for (int j = 0; j < WORK_PER_THREAD; ++j) {
-        cs[(gid0 + j) + gid1 * N] = res[j];
+        cs[gid1 + (gid0 + j) * N] = res[j];
     }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,63 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+__kernel void matrix_transpose_naive(
+    __global const float* as,
+    __global float* as_t,
+    int M,
+    int K)
 {
-    // TODO
+    int gid0 = get_global_id(0);
+    int gid1 = get_global_id(1);
+    if (gid0 < M && gid1 < K) {
+        as_t[gid1 * M + gid0] = as[gid0 * K + gid1];
+    }
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_local_bad_banks(
+    __global const float* as,
+    __global float* as_t,
+    int M,
+    int K)
 {
-    // TODO
+    int gid0 = get_global_id(0);
+    int gid1 = get_global_id(1);
+    int lid0 = get_local_id(0);
+    int lid1 = get_local_id(1);
+
+    __local float buf[TILE_SIZE][TILE_SIZE];
+
+    buf[lid1][lid0] = as[gid0 * K + gid1];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    gid0 += lid1 - lid0;
+    gid1 += lid0 - lid1;
+
+    as_t[gid1 * M + gid0] = buf[lid0][lid1];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(
+    __global const float* as,
+    __global float* as_t,
+    int M,
+    int K)
 {
-    // TODO
+    int gid0 = get_global_id(0);
+    int gid1 = get_global_id(1);
+    int lid0 = get_local_id(0);
+    int lid1 = get_local_id(1);
+
+    __local float buf[TILE_SIZE][TILE_SIZE];
+
+    buf[lid1][(lid0 + lid1) % TILE_SIZE] = as[gid0 * K + gid1];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    gid0 += lid1 - lid0;
+    gid1 += lid0 - lid1;
+
+    as_t[gid1 * M + gid0] = buf[lid0][(lid1 + lid0) % TILE_SIZE];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -140,13 +140,13 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
 
-    // runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
-    // runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
-    // runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
+    runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
+    runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
+    runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
 
-    // runTest(makeLocalConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
-    // runTest(makeLocalConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
-    // runTest(makeLocalConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
+    runTest(makeLocalConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
+    runTest(makeLocalConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
+    runTest(makeLocalConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
 
     for (unsigned int tile_size : {4, 8, 16})
         for (unsigned int wpt : {2, 4, 8, 16})

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size / wpt, tile_size, M / wpt, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -143,16 +140,13 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
 
-    // TODO uncomment
-    return 0;
+    // runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
+    // runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
+    // runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
 
-    runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
-
-    runTest(makeLocalConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeLocalConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeLocalConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
+    // runTest(makeLocalConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
+    // runTest(makeLocalConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
+    // runTest(makeLocalConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
 
     for (unsigned int tile_size : {4, 8, 16})
         for (unsigned int wpt : {2, 4, 8, 16})

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -69,7 +69,7 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(tile_size / wpt, tile_size, M / wpt, N);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -34,8 +34,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
         // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(16, 16, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +73,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./matrix_transpose 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
  Device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Using device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00637145+-2.61957e-05 s
    GPU: 2633.19 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0129923+-2.56315e-06 s
    GPU: 1291.32 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0129813+-2.14858e-06 s
    GPU: 1292.41 millions/s
</pre>

<pre>
$ ./matrix_multiplication 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 31982 Mb
  Device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Using device #1: GPU. NVIDIA GeForce MX130. Total memory: 1995 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.34632+-0 s
CPU: 0.597671 GFlops
[naive, ts=4]
    GPU: 0.13969+-5.03248e-05 s
    GPU: 14.3174 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.109055+-6.2361e-06 s
    GPU: 18.3394 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.177185+-1.94058e-05 s
    GPU: 11.2876 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.122242+-9.01234e-06 s
    GPU: 16.361 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.0532615+-6.3705e-06 s
    GPU: 37.5506 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0645237+-1.11156e-05 s
    GPU: 30.9964 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.130971+-2.3956e-05 s
    GPU: 15.2706 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.157707+-1.45993e-05 s
    GPU: 12.6817 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.0527665+-4.11299e-06 s
    GPU: 37.9028 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.0527917+-4.02768e-06 s
    GPU: 37.8848 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.0532477+-3.19722e-06 s
    GPU: 37.5603 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0937727+-2.02375e-05 s
    GPU: 21.3282 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0463642+-1.14661e-05 s
    GPU: 43.1368 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0139672+-1.80685e-05 s
    GPU: 143.193 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0154663+-1.01926e-05 s
    GPU: 129.313 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.017608+-0.00129489 s
    GPU: 952.816 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0346907+-0.000495818 s
    GPU: 483.623 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0346617+-0.000567299 s
    GPU: 484.028 millions/s
</pre>

<pre>
./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.1249+-0 s
CPU: 0.326536 GFlops
[naive, ts=4]
    GPU: 0.275037+-0.0135655 s
    GPU: 7.27174 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.287615+-0.0242698 s
    GPU: 6.95374 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.273759+-0.00228796 s
    GPU: 7.30569 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.53324+-0.00119424 s
    GPU: 3.75066 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.288993+-0.00299233 s
    GPU: 6.92059 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.274985+-0.000237061 s
    GPU: 7.27312 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.516406+-0.00161079 s
    GPU: 3.87292 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.458102+-0.00184943 s
    GPU: 4.36584 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.316823+-0.00122149 s
    GPU: 6.31267 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.306271+-0.000580828 s
    GPU: 6.53015 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.277932+-0.000177691 s
    GPU: 7.196 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.236632+-0.000532689 s
    GPU: 8.45194 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.230328+-0.0006218 s
    GPU: 8.68329 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.197159+-0.00257755 s
    GPU: 10.1441 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.192271+-0.00100487 s
    GPU: 10.402 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>

### matrix_transpose
Улучшение с использованием локальной памяти и коалесд доступом улучшило эффективность примерно в 2 раза, а вот исправление банк конфликтов почему-то ничего не поменяло (хотя вроде правильно реализовал).

### matrix_multiplication
Улучшение с использованием локальной памяти опять же улучшило эффективность примерно в 2 раза, при чем лучший TILE_SIZE в этих экспериментах оказался 8. Использование WPT ещё улучшило эффективность, при чем вариант TILE_SIZE=16, WPT=8 - самый эффективный. 