### PR TITLE
Task04 Данил Конев SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -74,7 +74,7 @@ __kernel void matrix_multiplication_local_wpt(
     for (int t = 0; t * TILE_SIZE < k; t++) {
         for (int w = 0; w < WORK_PER_THREAD; w++) {
             TileA[row + w * RTS][col] = a[(global_row + w * RTS) * k + t * TILE_SIZE + col];
-            TileB[row][col] = b[(t * TILE_SIZE + row) * n + global_col];
+            TileB[row + w * RTS][col] = b[(t * TILE_SIZE + row + w * RTS) * n + global_col];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
 

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,88 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(
+        __global const float *a, __global const float *b, __global float *c,
+        int m, int k, int n)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float s = 0;
+    for (int l = 0; l < k; l++) {
+        s += a[j * k + l] * b[l * n + i];
+    }
+
+    c[j * n + i] = s;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(
+        __global const float *a, __global const float *b, __global float *c,
+        int m, int k, int n)
 {
-    // TODO
+    int col = get_local_id(0);
+    int row = get_local_id(1);
+
+    int global_col = get_group_id(0) * TILE_SIZE + col;
+    int global_row = get_group_id(1) * TILE_SIZE + row;
+
+    __local float TileA[TILE_SIZE][TILE_SIZE];
+    __local float TileB[TILE_SIZE][TILE_SIZE];
+
+    float s = 0;
+    for (int t = 0; t * TILE_SIZE < k; t++) {
+        TileA[row][col] = a[global_row * k + t * TILE_SIZE + col];
+        TileB[row][col] = b[(t * TILE_SIZE + row) * n + global_col];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int i = 0; i < TILE_SIZE; i++) {
+            s += TileA[row][i] * TileB[i][col];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    c[global_row * n + global_col] = s;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(
+        __global const float *a, __global const float *b, __global float *c,
+        int m, int k, int n)
 {
-    // TODO
+    int col = get_local_id(0);
+    int row = get_local_id(1);
+
+    const int RTS = TILE_SIZE / WORK_PER_THREAD;
+
+    int global_col = get_group_id(0) * TILE_SIZE + col;
+    int global_row = get_group_id(1) * TILE_SIZE + row;
+
+    __local float TileA[TILE_SIZE][TILE_SIZE];
+    __local float TileB[TILE_SIZE][TILE_SIZE];
+
+    float s[WORK_PER_THREAD] = {0};
+
+    for (int t = 0; t * TILE_SIZE < k; t++) {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            TileA[row + w * RTS][col] = a[(global_row + w * RTS) * k + t * TILE_SIZE + col];
+            TileB[row][col] = b[(t * TILE_SIZE + row) * n + global_col];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int i = 0; i < TILE_SIZE; i++) {
+            for (int w = 0; w < WORK_PER_THREAD; w++) {
+                s[w] += TileA[row + w * RTS][i] * TileB[i][col];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        c[(global_row + w * RTS) * n + global_col] = s[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,41 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_naive(__global float *a, __global float *at, const int m, const int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    at[i * m + j] = a[j * k + i];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+__kernel void matrix_transpose_local_bad_banks(__global float *a, __global float *at, const int M, const int K)
 {
-    // TODO
+    __local float tile[TILE_SIZE * TILE_SIZE];
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    tile[li * TILE_SIZE + lj] = a[j * K + i];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[(get_group_id(0) * TILE_SIZE + lj) * K + get_group_id(1) * TILE_SIZE + li] = tile[lj * TILE_SIZE + li];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(__global float *a, __global float *at, const int M, const int K)
 {
-    // TODO
+    __local float tile[TILE_SIZE * (TILE_SIZE + 1)];
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    tile[lj * (TILE_SIZE + 1) + li] = a[j * K + i];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[(get_group_id(0) * TILE_SIZE + lj) * K + get_group_id(1) * TILE_SIZE + li] = tile[li * (TILE_SIZE + 1) + lj];
 }

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -34,8 +34,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
         // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(16, 16, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +73,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./matrix_transpose
OpenCL devices:
  Device #0: GPU. Apple M2. Total memory: 5461 Mb
Using device #0: GPU. Apple M2. Total memory: 5461 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00183733+-3.80516e-05 s
    GPU: 9131.29 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.00182022+-2.45853e-05 s
    GPU: 9217.15 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.00180377+-2.44093e-05 s
    GPU: 9301.21 millions/s

$ ./matrix_multiplication
OpenCL devices:
  Device #0: GPU. Apple M2. Total memory: 5461 Mb
Using device #0: GPU. Apple M2. Total memory: 5461 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.79174+-1.41629e-08 s
CPU: 0.527462 GFlops
[naive, ts=4]
    GPU: 0.0122115+-0.000476769 s
    GPU: 163.78 GFlops
    Average difference: 0%
[naive, ts=8]
    GPU: 0.0161957+-0.000438779 s
    GPU: 123.49 GFlops
    Average difference: 0%
[naive, ts=16]
    GPU: 0.0118767+-0.00039979 s
    GPU: 168.397 GFlops
    Average difference: 0%
[local, ts=4]
    GPU: 0.016141+-0.000714008 s
    GPU: 123.908 GFlops
    Average difference: 0%
[local, ts=8]
    GPU: 0.00592617+-0.000109758 s
    GPU: 337.486 GFlops
    Average difference: 0%
[local, ts=16]
    GPU: 0.00522333+-0.000135656 s
    GPU: 382.897 GFlops
    Average difference: 0%
[local wpt, ts=4, wpt=2]
    GPU: 0.0223027+-0.000515098 s
    GPU: 89.6754 GFlops
    Average difference: 0%
[local wpt, ts=4, wpt=4]
    GPU: 0.0370613+-0.000280732 s
    GPU: 53.9646 GFlops
    Average difference: 0%
[local wpt, ts=8, wpt=2]
    GPU: 0.00453133+-2.25807e-05 s
    GPU: 441.371 GFlops
    Average difference: 0%
[local wpt, ts=8, wpt=4]
    GPU: 0.00747317+-2.97681e-05 s
    GPU: 267.624 GFlops
    Average difference: 0%
[local wpt, ts=8, wpt=8]
    GPU: 0.0173278+-0.000459474 s
    GPU: 115.421 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=2]
    GPU: 0.00449667+-3.01367e-05 s
    GPU: 444.774 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=4]
    GPU: 0.00366533+-2.25955e-05 s
    GPU: 545.653 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=8]
    GPU: 0.0040725+-2.22017e-05 s
    GPU: 491.099 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=16]
    GPU: 0.0114167+-9.26942e-05 s
    GPU: 175.182 GFlops
    Average difference: 0%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0161321+-0.000144695 s
    GPU: 1039.99 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0133337+-5.87615e-05 s
    GPU: 1258.26 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0142759+-5.10294e-05 s
    GPU: 1175.21 millions/s

$ ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.08544+-0 s
CPU: 0.328653 GFlops
[naive, ts=4]
    GPU: 0.278694+-0.00796799 s
    GPU: 7.17632 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.271026+-0.00315905 s
    GPU: 7.37937 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.31961+-0.0282449 s
    GPU: 6.25762 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.594748+-0.000545432 s
    GPU: 3.36277 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.109308+-0.000198738 s
    GPU: 18.2969 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0699212+-0.000325857 s
    GPU: 28.6036 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.539262+-0.00272789 s
    GPU: 3.70877 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.475112+-0.00168706 s
    GPU: 4.20954 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.135911+-0.000502784 s
    GPU: 14.7155 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.151507+-0.000329341 s
    GPU: 13.2007 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.143789+-0.000426475 s
    GPU: 13.9093 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0847648+-0.000240268 s
    GPU: 23.5947 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0771217+-0.000196725 s
    GPU: 25.933 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0788197+-0.000917917 s
    GPU: 25.3744 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0921885+-0.000260632 s
    GPU: 21.6947 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>