### PR TITLE
Task04 Валерий Мацкевич HSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build
 cmake-build*
 .vs
+.history
+.vscode

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,95 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(
+    __global const float *lhs, 
+    __global const float *rhs,
+    __global float *result,
+    unsigned m, unsigned k, unsigned n)
 {
-    // TODO
+    const int gid_x = get_global_id(0);
+    const int gid_y = get_global_id(1);
+
+    float sum = 0;
+    for (int i = 0; i < k; i++) {
+        sum += lhs[gid_x * k + i] * rhs[i * n + gid_y];
+    }
+
+    result[gid_x * n + gid_y] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(
+    __global const float *lhs, 
+    __global const float *rhs,
+    __global float *result,
+    unsigned m, unsigned k, unsigned n)
 {
-    // TODO
+    const int gid_x = get_global_id(0);
+    const int gid_y = get_global_id(1);
+    const int lid_x = get_local_id(0);
+    const int lid_y = get_local_id(1);
+
+    __local float lhs_tile[TILE_SIZE][TILE_SIZE];
+    __local float rhs_tile[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0;
+    for (int tile = 0; tile < k; tile += TILE_SIZE) {
+        lhs_tile[lid_x][lid_y] = lhs[gid_x * k + lid_y + tile];
+        rhs_tile[lid_x][lid_y] = rhs[(lid_x + tile) * n + gid_y];
+    
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int i = 0; i < TILE_SIZE; i++) {
+            sum += lhs_tile[lid_x][i] * rhs_tile[i][lid_y];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    result[gid_x * n + gid_y] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(
+    __global const float *lhs, 
+    __global const float *rhs,
+    __global float *result,
+    unsigned m, unsigned k, unsigned n)
 {
-    // TODO
+    const int gid_x = get_global_id(0);
+    const int gid_y = get_global_id(1);
+    const int lid_x = get_local_id(0);
+    const int lid_y = get_local_id(1);
+
+    __local float lhs_tile[TILE_SIZE][TILE_SIZE];
+    __local float rhs_tile[TILE_SIZE][TILE_SIZE];
+
+    // for some reason, `sum[WORK_PER_THREAD] = { 0 }` doesn't work (sic!):
+    float sum[WORK_PER_THREAD];
+    for (int i = 0; i < WORK_PER_THREAD; i++) {
+        sum[i] = 0;
+    }
+    for (int tile = 0; tile < k; tile += TILE_SIZE) {
+        for (int i = 0; i < WORK_PER_THREAD; i++) {
+            lhs_tile[lid_x * WORK_PER_THREAD + i][lid_y] = lhs[(gid_x * WORK_PER_THREAD + i) * k + lid_y + tile];
+            rhs_tile[lid_x * WORK_PER_THREAD + i][lid_y] = rhs[(lid_x * WORK_PER_THREAD + tile + i) * n + gid_y];
+        }
+    
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int i = 0; i < WORK_PER_THREAD; i++) {
+            for (int j = 0; j < TILE_SIZE; j++) {
+                sum[i] += lhs_tile[lid_x * WORK_PER_THREAD + i][j] * rhs_tile[j][lid_y];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int i = 0; i < WORK_PER_THREAD; i++) {
+        result[(gid_x * WORK_PER_THREAD + i) * n + gid_y] = sum[i];
+    }
 }
 #endif

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -36,24 +36,24 @@ __kernel void matrix_multiplication_local(
     const int lid_x = get_local_id(0);
     const int lid_y = get_local_id(1);
 
-    __local float lhs_tile[TILE_SIZE][TILE_SIZE];
-    __local float rhs_tile[TILE_SIZE][TILE_SIZE];
+    __local float lhs_tile[TILE_SIZE][TILE_SIZE + 1];
+    __local float rhs_tile[TILE_SIZE][TILE_SIZE + 1];
 
     float sum = 0;
     for (int tile = 0; tile < k; tile += TILE_SIZE) {
-        lhs_tile[lid_x][lid_y] = lhs[gid_x * k + lid_y + tile];
-        rhs_tile[lid_x][lid_y] = rhs[(lid_x + tile) * n + gid_y];
+        lhs_tile[lid_y][lid_x] = lhs[gid_y * k + tile + lid_x];
+        rhs_tile[lid_y][lid_x] = rhs[(tile + lid_y) * n + gid_x];
     
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (int i = 0; i < TILE_SIZE; i++) {
-            sum += lhs_tile[lid_x][i] * rhs_tile[i][lid_y];
+            sum += lhs_tile[lid_y][i] * rhs_tile[i][lid_x];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 
-    result[gid_x * n + gid_y] = sum;
+    result[gid_y * n + gid_x] = sum;
 }
 #endif
 
@@ -64,30 +64,35 @@ __kernel void matrix_multiplication_local_wpt(
     __global float *result,
     unsigned m, unsigned k, unsigned n)
 {
-    const int gid_x = get_global_id(0);
-    const int gid_y = get_global_id(1);
     const int lid_x = get_local_id(0);
     const int lid_y = get_local_id(1);
+    const int gid_x = get_group_id(0) * TILE_SIZE + lid_x;
+    const int gid_y = get_group_id(1) * TILE_SIZE + lid_y;
 
-    __local float lhs_tile[TILE_SIZE][TILE_SIZE];
-    __local float rhs_tile[TILE_SIZE][TILE_SIZE];
+    __local float lhs_tile[TILE_SIZE][TILE_SIZE + 1];
+    __local float rhs_tile[TILE_SIZE][TILE_SIZE + 1];
 
     // for some reason, `sum[WORK_PER_THREAD] = { 0 }` doesn't work (sic!):
     float sum[WORK_PER_THREAD];
     for (int i = 0; i < WORK_PER_THREAD; i++) {
         sum[i] = 0;
     }
+
     for (int tile = 0; tile < k; tile += TILE_SIZE) {
         for (int i = 0; i < WORK_PER_THREAD; i++) {
-            lhs_tile[lid_x * WORK_PER_THREAD + i][lid_y] = lhs[(gid_x * WORK_PER_THREAD + i) * k + lid_y + tile];
-            rhs_tile[lid_x * WORK_PER_THREAD + i][lid_y] = rhs[(lid_x * WORK_PER_THREAD + tile + i) * n + gid_y];
+            const int tid = i * (TILE_SIZE / WORK_PER_THREAD) + lid_y;
+            const int lhs_tid = (i * (TILE_SIZE / WORK_PER_THREAD) + gid_y) * k + lid_x + tile;
+            const int rhs_tid = (i * (TILE_SIZE / WORK_PER_THREAD) + lid_y + tile) * n + gid_x;
+
+            lhs_tile[tid][lid_x] = lhs[lhs_tid];
+            rhs_tile[tid][lid_x] = rhs[rhs_tid];
         }
     
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (int i = 0; i < WORK_PER_THREAD; i++) {
             for (int j = 0; j < TILE_SIZE; j++) {
-                sum[i] += lhs_tile[lid_x * WORK_PER_THREAD + i][j] * rhs_tile[j][lid_y];
+                sum[i] += lhs_tile[i * (TILE_SIZE / WORK_PER_THREAD) + lid_y][j] * rhs_tile[j][lid_x];
             }
         }
 
@@ -95,7 +100,7 @@ __kernel void matrix_multiplication_local_wpt(
     }
 
     for (int i = 0; i < WORK_PER_THREAD; i++) {
-        result[(gid_x * WORK_PER_THREAD + i) * n + gid_y] = sum[i];
+        result[(i * (TILE_SIZE / WORK_PER_THREAD) + gid_y) * n + gid_x] = sum[i];
     }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -8,21 +8,17 @@
 #define TILE_SIZE 16
 
 __kernel void matrix_transpose_naive(
-    __global const float* matrix,
-    __global float* transposed,
+    __global const float* matrix, __global float* transposed,
     unsigned int width, unsigned int height)
 {
     const int gid_x = get_global_id(0);
     const int gid_y = get_global_id(1);
 
-    if (gid_x < height && gid_y < width) {
-        transposed[gid_x * width + gid_y] = matrix[gid_y * height + gid_x];
-    }
+    transposed[gid_x * width + gid_y] = matrix[gid_y * height + gid_x];
 }
 
 __kernel void matrix_transpose_local_bad_banks(
-    __global const float* matrix,
-    __global float* transposed,
+    __global const float* matrix, __global float* transposed,
     unsigned int width, unsigned int height)
 {
     const int gid_x = get_global_id(0);
@@ -39,8 +35,7 @@ __kernel void matrix_transpose_local_bad_banks(
 }
 
 __kernel void matrix_transpose_local_good_banks(
-    __global const float* matrix,
-    __global float* transposed,
+    __global const float* matrix, __global float* transposed,
     unsigned int width, unsigned int height)
 {
     const int gid_x = get_global_id(0);

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -25,13 +25,14 @@ __kernel void matrix_transpose_local_bad_banks(
     const int gid_y = get_global_id(1);
     const int lid_x = get_local_id(0);
     const int lid_y = get_local_id(1);
+    const int tid = (get_group_id(0) * TILE_SIZE + lid_y) * width + get_group_id(1) * TILE_SIZE + lid_x;
 
     __local float buffer[TILE_SIZE][TILE_SIZE];
-    buffer[lid_x][lid_y] = matrix[gid_x * height + gid_y];
+    buffer[lid_y][lid_x] = matrix[gid_y * height + gid_x];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    transposed[gid_y * width + gid_x] = buffer[lid_x][lid_y];
+    transposed[tid] = buffer[lid_x][lid_y];
 }
 
 __kernel void matrix_transpose_local_good_banks(
@@ -42,11 +43,12 @@ __kernel void matrix_transpose_local_good_banks(
     const int gid_y = get_global_id(1);
     const int lid_x = get_local_id(0);
     const int lid_y = get_local_id(1);
+    const int tid = (get_group_id(0) * TILE_SIZE + lid_y) * width + get_group_id(1) * TILE_SIZE + lid_x;
 
     __local float buffer[TILE_SIZE][TILE_SIZE + 1];
-    buffer[lid_y][lid_x] = matrix[gid_x * height + gid_y];
+    buffer[lid_x][lid_y] = matrix[gid_y * height + gid_x];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    transposed[gid_y * width + gid_x] = buffer[lid_y][lid_x];
+    transposed[tid] = buffer[lid_y][lid_x];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,53 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_naive(
+    __global const float* matrix,
+    __global float* transposed,
+    unsigned int width, unsigned int height)
 {
-    // TODO
+    const int gid_x = get_global_id(0);
+    const int gid_y = get_global_id(1);
+
+    if (gid_x < height && gid_y < width) {
+        transposed[gid_x * width + gid_y] = matrix[gid_y * height + gid_x];
+    }
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+__kernel void matrix_transpose_local_bad_banks(
+    __global const float* matrix,
+    __global float* transposed,
+    unsigned int width, unsigned int height)
 {
-    // TODO
+    const int gid_x = get_global_id(0);
+    const int gid_y = get_global_id(1);
+    const int lid_x = get_local_id(0);
+    const int lid_y = get_local_id(1);
+
+    __local float buffer[TILE_SIZE][TILE_SIZE];
+    buffer[lid_x][lid_y] = matrix[gid_x * height + gid_y];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    transposed[gid_y * width + gid_x] = buffer[lid_x][lid_y];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(
+    __global const float* matrix,
+    __global float* transposed,
+    unsigned int width, unsigned int height)
 {
-    // TODO
+    const int gid_x = get_global_id(0);
+    const int gid_y = get_global_id(1);
+    const int lid_x = get_local_id(0);
+    const int lid_y = get_local_id(1);
+
+    __local float buffer[TILE_SIZE][TILE_SIZE + 1];
+    buffer[lid_y][lid_x] = matrix[gid_x * height + gid_y];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    transposed[gid_y * width + gid_x] = buffer[lid_y][lid_x];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -1,25 +1,25 @@
-#include <libutils/misc.h>
-#include <libutils/timer.h>
-#include <libutils/fast_random.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/matrix_multiplication_cl.h"
 
-#include <vector>
 #include <iostream>
 #include <stdexcept>
+#include <vector>
 
 const int benchmarkingIters = 10;
 const int benchmarkingItersCPU = 1;
 const unsigned int M = 1024;
 const unsigned int K = 1024;
 const unsigned int N = 1024;
-const size_t gflops = ((size_t) M * K * N * 2) / (1000 * 1000 * 1000); // умножить на два, т.к. операция сложения и умножения
+const size_t gflops =
+        ((size_t) M * K * N * 2) / (1000 * 1000 * 1000);// умножить на два, т.к. операция сложения и умножения
 
-std::vector<float> computeCPU(const float *as, const float *bs)
-{
-    std::vector<float> cs(M*N, 0);
+std::vector<float> computeCPU(const float *as, const float *bs) {
+    std::vector<float> cs(M * N, 0);
 
     timer t;
     for (int iter = 0; iter < benchmarkingItersCPU; ++iter) {
@@ -48,47 +48,41 @@ struct KernelConfig {
     std::string prefix;
 };
 
-KernelConfig makeNaiveConfig(unsigned int tile_size)
-{
-    throw std::runtime_error("not implemented");
+KernelConfig makeNaiveConfig(unsigned int tile_size) {
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
 }
 
-KernelConfig makeLocalConfig(unsigned int tile_size)
-{
-    throw std::runtime_error("not implemented");
+KernelConfig makeLocalConfig(unsigned int tile_size) {
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
 }
 
-KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
-{
-    throw std::runtime_error("not implemented");
+KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt) {
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size / wpt, tile_size, M / wpt, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
 }
 
-void runTest(const KernelConfig &config, const float *as, const float *bs, const float *cs_cpu_reference)
-{
+void runTest(const KernelConfig &config, const float *as, const float *bs, const float *cs_cpu_reference) {
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
-    as_gpu.resizeN(M*K);
-    bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
+    as_gpu.resizeN(M * K);
+    bs_gpu.resizeN(K * N);
+    cs_gpu.resizeN(M * N);
 
-    as_gpu.writeN(as, M*K);
-    bs_gpu.writeN(bs, K*N);
+    as_gpu.writeN(as, M * K);
+    bs_gpu.writeN(bs, K * N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, config.kernel_name, config.defines);
+    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, config.kernel_name,
+                                             config.defines);
     matrix_multiplication_kernel.compile();
 
     timer t;
@@ -101,8 +95,8 @@ void runTest(const KernelConfig &config, const float *as, const float *bs, const
     std::cout << "    GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
     std::cout << "    GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
 
-    std::vector<float> cs(M*N, 0);
-    cs_gpu.readN(cs.data(), M*N);
+    std::vector<float> cs(M * N, 0);
+    cs_gpu.readN(cs.data(), M * N);
 
     // Проверяем корректность результатов
     double diff_sum = 0;
@@ -116,23 +110,22 @@ void runTest(const KernelConfig &config, const float *as, const float *bs, const
     }
 
     double diff_avg = diff_sum / (M * N);
-    std::cout <<"    Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+    std::cout << "    Average difference: " << diff_avg * 100.0 << "%" << std::endl;
     if (diff_avg > 0.01) {
         throw std::runtime_error("Too big difference!");
     }
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     gpu::Context context;
     context.init(device.device_id_opencl);
     context.activate();
 
-    std::vector<float> as(M*K, 0);
-    std::vector<float> bs(K*N, 0);
-    FastRandom r(M+K+N);
+    std::vector<float> as(M * K, 0);
+    std::vector<float> bs(K * N, 0);
+    FastRandom r(M + K + N);
     for (unsigned int i = 0; i < as.size(); ++i) {
         as[i] = r.nextf();
     }
@@ -142,9 +135,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -66,7 +66,7 @@ KernelConfig makeLocalConfig(unsigned int tile_size) {
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt) {
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(tile_size / wpt, tile_size, M / wpt, N);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -1,14 +1,14 @@
-#include <libutils/misc.h>
-#include <libutils/timer.h>
-#include <libutils/fast_random.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/matrix_transpose_cl.h"
 
-#include <vector>
 #include <iostream>
 #include <stdexcept>
+#include <vector>
 
 const int benchmarkingIters = 100;
 const unsigned int M = 4096;
@@ -16,17 +16,16 @@ const unsigned int K = 4096;
 
 namespace {
 
-constexpr unsigned WORK_SIZE_PER_AXIS = 16;
+    constexpr unsigned WORK_SIZE_PER_AXIS = 16;
 
-}  // namespace
+}// namespace
 
-void runTest(const std::string &kernel_name, const float *as)
-{
+void runTest(const std::string &kernel_name, const float *as) {
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
-    as_gpu.resizeN(M*K);
-    as_t_gpu.resizeN(K*M);
+    as_gpu.resizeN(M * K);
+    as_t_gpu.resizeN(K * M);
 
-    as_gpu.writeN(as, M*K);
+    as_gpu.writeN(as, M * K);
 
     ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, kernel_name);
     matrix_transpose_kernel.compile();
@@ -47,10 +46,10 @@ void runTest(const std::string &kernel_name, const float *as)
 
     std::cout << "[" << kernel_name << "]" << std::endl;
     std::cout << "    GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-    std::cout << "    GPU: " << M*K/1000.0/1000.0 / t.lapAvg() << " millions/s" << std::endl;
+    std::cout << "    GPU: " << M * K / 1000.0 / 1000.0 / t.lapAvg() << " millions/s" << std::endl;
 
-    std::vector<float> as_t(M*K, 0);
-    as_t_gpu.readN(as_t.data(), M*K);
+    std::vector<float> as_t(M * K, 0);
+    as_t_gpu.readN(as_t.data(), M * K);
 
     // Проверяем корректность результатов
     for (int j = 0; j < M; ++j) {
@@ -64,16 +63,15 @@ void runTest(const std::string &kernel_name, const float *as)
     }
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     gpu::Context context;
     context.init(device.device_id_opencl);
     context.activate();
 
-    std::vector<float> as(M*K, 0);
-    FastRandom r(M+K);
+    std::vector<float> as(M * K, 0);
+    FastRandom r(M + K);
     for (unsigned int i = 0; i < as.size(); ++i) {
         as[i] = r.nextf();
     }

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -14,6 +14,12 @@ const int benchmarkingIters = 100;
 const unsigned int M = 4096;
 const unsigned int K = 4096;
 
+namespace {
+
+constexpr unsigned WORK_SIZE_PER_AXIS = 16;
+
+}  // namespace
+
 void runTest(const std::string &kernel_name, const float *as)
 {
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
@@ -33,9 +39,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(WORK_SIZE_PER_AXIS, WORK_SIZE_PER_AXIS, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +78,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./build/matrix_transpose 
OpenCL devices:
  Device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
Using device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0169246+-0.000363228 s
    GPU: 991.289 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0162895+-3.76592e-05 s
    GPU: 1029.94 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0162737+-4.11965e-05 s
    GPU: 1030.94 millions/s
$ ./build/matrix_multiplication 
OpenCL devices:
  Device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
Using device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 10.3802+-0 s
CPU: 0.192675 GFlops
[naive, ts=4]
    GPU: 0.929132+-0.00651321 s
    GPU: 2.15255 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.939817+-0.00427403 s
    GPU: 2.12807 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 1.20814+-0.00336305 s
    GPU: 1.65544 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.65125+-0.306172 s
    GPU: 3.07102 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.564746+-0.284267 s
    GPU: 3.54142 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.310659+-0.00316622 s
    GPU: 6.43794 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 1.23883+-0.633773 s
    GPU: 1.61442 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.543547+-0.0472318 s
    GPU: 3.67953 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.59599+-0.21084 s
    GPU: 3.35576 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.671404+-0.117922 s
    GPU: 2.97883 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.524906+-0.18261 s
    GPU: 3.81021 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.391485+-0.0641349 s
    GPU: 5.10876 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.445875+-0.146809 s
    GPU: 4.48556 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.498357+-0.0494717 s
    GPU: 4.01319 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.361147+-0.04432 s
    GPU: 5.53792 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0152054+-0.000145498 s
    GPU: 1103.37 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0225613+-0.000898613 s
    GPU: 743.627 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0224438+-0.000941109 s
    GPU: 747.522 millions/s
$ ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.33776+-0 s
CPU: 0.315569 GFlops
[naive, ts=4]
    GPU: 0.368016+-0.00387518 s
    GPU: 5.43454 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.373403+-0.00552401 s
    GPU: 5.35614 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.372796+-0.00299166 s
    GPU: 5.36486 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.536499+-0.000822247 s
    GPU: 3.72787 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.310242+-0.00216126 s
    GPU: 6.44658 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.2867+-0.00103005 s
    GPU: 6.97592 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.514041+-0.00417185 s
    GPU: 3.89074 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.441325+-0.00117908 s
    GPU: 4.53181 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.318689+-0.00104722 s
    GPU: 6.2757 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.284307+-0.00114197 s
    GPU: 7.03465 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.275566+-0.00210648 s
    GPU: 7.25779 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.239857+-0.00118266 s
    GPU: 8.33831 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.227042+-0.00149647 s
    GPU: 8.80894 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.199619+-0.00168463 s
    GPU: 10.0191 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>
