### PR TITLE
Task04 Petr Ivanov ITMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/*_cl.h
 .idea
+.vscode
 build
 cmake-build*
 .vs

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,97 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(__global float* left, __global float* right, __global float* result,
+                                          const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+
+    if (gidx >= M || gidy >= N)
+        return;
+
+    float result_ = 0;
+
+    for (int i = 0; i < K; i++)
+        result_ += left[gidx * M + i] * right[i * N + gidy];
+
+    result[gidx * N + gidy] = result_;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(__global float* left, __global float* right, __global float* result,
+                                          const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+
+    const unsigned int lidx = get_local_id(0);
+    const unsigned int lidy = get_local_id(1);
+
+    const unsigned int numTiles = (K + TILE_SIZE - 1) / TILE_SIZE;
+
+    __local float leftTile[TILE_SIZE][TILE_SIZE];
+    __local float rightTile[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0;
+
+    for (int t = 0; t < numTiles; t++)
+    {
+        leftTile[lidy][lidx] = left[gidy * K + t * TILE_SIZE + lidx];
+        rightTile[lidy][lidx] = right[(t * TILE_SIZE + lidy) * N + gidx];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int i = 0; i < TILE_SIZE; i++)
+        {
+            sum += leftTile[lidy][i] * rightTile[i][lidx];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    result[gidy * N + gidx] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(__global float* left, __global float* right, __global float* result,
+                                              const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+
+    const unsigned int lidx = get_local_id(0);
+    const unsigned int lidy = get_local_id(1);
+
+    const unsigned int numTiles = (K + TILE_SIZE - 1) / TILE_SIZE;
+
+    __local float leftTile[TILE_SIZE][TILE_SIZE];
+    __local float rightTile[TILE_SIZE][TILE_SIZE];
+
+    float wpt_accumulator[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; w++)
+        wpt_accumulator[w] = 0;
+
+    for (int t = 0; t < numTiles; t++)
+    {
+        for (int w = 0; w < WORK_PER_THREAD; w++)
+        {
+            leftTile[lidy * WORK_PER_THREAD + w][lidx] = left[(gidy * WORK_PER_THREAD + w) * K + t * TILE_SIZE + lidx];
+            rightTile[lidy * WORK_PER_THREAD + w][lidx] = right[(t * TILE_SIZE + lidy * WORK_PER_THREAD + w) * N + gidx];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int i = 0; i < TILE_SIZE; i++)
+        {
+            for (int w = 0; w < WORK_PER_THREAD; w++)
+            {
+                wpt_accumulator[w] += leftTile[lidy * WORK_PER_THREAD + w][i] * rightTile[i][lidx];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    for (int w = 0; w < WORK_PER_THREAD; w++)
+        result[(gidy * WORK_PER_THREAD + w) * N + gidx] = wpt_accumulator[w];
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -14,15 +14,12 @@ __kernel void matrix_transpose_naive(__global float* matrix, __global float* res
     result[gidx * height + gidy] = matrix[gidy * width + gidx];
 }
 
-__kernel void matrix_transpose_local_bad_banks(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
+__kernel void matrix_transpose_local_bad_banks_non_coalesced(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
 {
     const unsigned int gidx = get_global_id(0);
     const unsigned int gidy = get_global_id(1);
     const unsigned int lidx = get_local_id(0);
     const unsigned int lidy = get_local_id(1);
-
-//    if (gidx + gidy == 0)
-//    printf(" (%d, %d) ", lidx, lidy);
 
     // https://nanoreview.net/en/gpu/geforce-rtx-3090
     // 128KB на compute unit, которых 82 штуки, всего 10496 потока. Зная, что в варп nVidia кладет 32 потока получаем 4 варпа на compute unit
@@ -33,13 +30,53 @@ __kernel void matrix_transpose_local_bad_banks(__global float* matrix, __global 
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    float temp = groupData[lidy][lidx];
-    groupData[lidy][lidx] = groupData[lidx][lidy];
+    // Заодно тут убрал транспонирование в локальной памяти, зачем я его добавил вообще?
+
+    result[gidx * height + gidy] = groupData[lidy][lidx];
+}
+
+__kernel void matrix_transpose_local_bad_banks(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
+{
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+    const unsigned int lidx = get_local_id(0);
+    const unsigned int lidy = get_local_id(1);
+
+    // https://nanoreview.net/en/gpu/geforce-rtx-3090
+    // 128KB на compute unit, которых 82 штуки, всего 10496 потока. Зная, что в варп nVidia кладет 32 потока получаем 4 варпа на compute unit
+    // Значит, один варп может претендовать на 32KB памяти. Посчитал это все, но выделю 4KB как было на лекции, мало ли...
+    __local float groupData[SUBMATRIX_SIZE][SUBMATRIX_SIZE];
+
+    groupData[lidy][lidx] = matrix[gidy * width + gidx];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    groupData[lidx][lidy] = temp;
-    result[gidx * width + gidy] = groupData[lidx][lidy];
+    // lid (x, y): (0, 0), (1, 0), (2, 0), ... (0, 1), (1, 1), (2, 1), ...
+    // result (x, y): (gidy, gidx), (gidy + 1, gidx - 1), (gidy + 2, gidx - 2)
+    // у результата получаются соседние x, и одинаковые y т.к. y = gidx - lidx всегда дает одно и то же у соседних потоков (lidx и gidx внутри рабочей группы растут одинаково)
+    // при этом глобальные индексы мы используем как опору
+
+    const int resultIdx = gidy - lidy + lidx;
+    const int resultIdy = gidx - lidx + lidy;
+
+    result[resultIdy * width + resultIdx] = groupData[lidx][lidy];
+}
+
+__kernel void matrix_transpose_local_good_banks_non_coalesced(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
+{
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+    const unsigned int lidx = get_local_id(0);
+    const unsigned int lidy = get_local_id(1);
+
+    __local float groupData[SUBMATRIX_SIZE][SUBMATRIX_SIZE];
+
+    const unsigned int stairIndex = (lidx + lidy) % SUBMATRIX_SIZE;
+    groupData[lidy][stairIndex] = matrix[gidy * width + gidx];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    result[gidx * height + gidy] = groupData[lidy][stairIndex];
 }
 
 __kernel void matrix_transpose_local_good_banks(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
@@ -56,11 +93,8 @@ __kernel void matrix_transpose_local_good_banks(__global float* matrix, __global
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    float temp = groupData[lidy][stairIndex];
-    groupData[lidy][stairIndex] = groupData[stairIndex][lidy];
+    const int resultIdx = gidy - lidy + lidx;
+    const int resultIdy = gidx - lidx + lidy;
 
-    barrier(CLK_LOCAL_MEM_FENCE);
-
-    groupData[stairIndex][lidy] = temp;
-    result[gidx * width + gidy] = groupData[stairIndex][lidy];
+    result[resultIdy * width + resultIdx] = groupData[lidx][stairIndex];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -4,18 +4,63 @@
 
 
 #line 6
+#define SUBMATRIX_SIZE 16
 
-__kernel void matrix_transpose_naive()
+__kernel void matrix_transpose_naive(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
 {
-    // TODO
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+
+    result[gidx * height + gidy] = matrix[gidy * width + gidx];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+__kernel void matrix_transpose_local_bad_banks(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
 {
-    // TODO
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+    const unsigned int lidx = get_local_id(0);
+    const unsigned int lidy = get_local_id(1);
+
+//    if (gidx + gidy == 0)
+//    printf(" (%d, %d) ", lidx, lidy);
+
+    // https://nanoreview.net/en/gpu/geforce-rtx-3090
+    // 128KB на compute unit, которых 82 штуки, всего 10496 потока. Зная, что в варп nVidia кладет 32 потока получаем 4 варпа на compute unit
+    // Значит, один варп может претендовать на 32KB памяти. Посчитал это все, но выделю 4KB как было на лекции, мало ли...
+    __local float groupData[SUBMATRIX_SIZE][SUBMATRIX_SIZE];
+
+    groupData[lidy][lidx] = matrix[gidy * width + gidx];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    float temp = groupData[lidy][lidx];
+    groupData[lidy][lidx] = groupData[lidx][lidy];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    groupData[lidx][lidy] = temp;
+    result[gidx * width + gidy] = groupData[lidx][lidy];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(__global float* matrix, __global float* result, const unsigned int width, const unsigned int height)
 {
-    // TODO
+    const unsigned int gidx = get_global_id(0);
+    const unsigned int gidy = get_global_id(1);
+    const unsigned int lidx = get_local_id(0);
+    const unsigned int lidy = get_local_id(1);
+
+    __local float groupData[SUBMATRIX_SIZE][SUBMATRIX_SIZE];
+
+    const unsigned int stairIndex = (lidx + lidy) % SUBMATRIX_SIZE;
+    groupData[lidy][stairIndex] = matrix[gidy * width + gidx];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    float temp = groupData[lidy][stairIndex];
+    groupData[lidy][stairIndex] = groupData[stairIndex][lidy];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    groupData[stairIndex][lidy] = temp;
+    result[gidx * width + gidy] = groupData[stairIndex][lidy];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(16, 16, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -143,8 +140,6 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
 
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -34,8 +34,11 @@ void runTest(const std::string &kernel_name, const float *as)
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
         // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        const unsigned int workGroupSize = 16;
+        const unsigned int workSizeX = (M + workGroupSize - 1) / workGroupSize * workGroupSize;
+        const unsigned int workSizeY = (K + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu::WorkSize work_size(workGroupSize, workGroupSize, workSizeX, workSizeY);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +76,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -78,7 +78,9 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
     runTest("matrix_transpose_naive", as.data());
+    runTest("matrix_transpose_local_bad_banks_non_coalesced", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());
+    runTest("matrix_transpose_local_good_banks_non_coalesced", as.data());
     runTest("matrix_transpose_local_good_banks", as.data());
 
     return 0;


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<details>
<summary>Matrix transpose</summary>
<p>
<pre>
/home/peter/GPGPUTasks2024/cmake-build-debug/matrix_transpose
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
Using device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.000243233+-4.22953e-07 s
    GPU: 68975.8 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.000233617+-6.60597e-07 s
    GPU: 71815.2 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000232067+-1.62138e-06 s
    GPU: 72294.8 millions/s
</pre>
</p>
</details>

<details>
<summary>Matrix multiplication</summary>
<p>
<pre>
/home/peter/GPGPUTasks2024/cmake-build-debug/matrix_multiplication
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
Using device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 2.43162+-0 s
CPU: 0.822496 GFlops
[naive, ts=4]
    GPU: 0.00421017+-0.00016401 s
    GPU: 475.041 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.00397117+-6.87184e-07 s
    GPU: 503.63 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.0039715+-1.25831e-06 s
    GPU: 503.588 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.003202+-0.00013292 s
    GPU: 624.61 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.000924+-5.7735e-07 s
    GPU: 2164.5 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.000690167+-6.87184e-07 s
    GPU: 2897.85 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.0044455+-0.000100354 s
    GPU: 449.893 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.00572633+-4.71405e-07 s
    GPU: 349.264 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.000755+-5.68624e-06 s
    GPU: 2649.01 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.0010215+-7.63763e-07 s
    GPU: 1957.91 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.00157267+-4.71405e-07 s
    GPU: 1271.73 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.000501833+-5.42046e-05 s
    GPU: 3985.39 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.000371333+-1.24722e-06 s
    GPU: 5386 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.000646167+-3.72678e-07 s
    GPU: 3095.18 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0013435+-0.000212748 s
    GPU: 1488.65 GFlops
    Average difference: 0.000149043%
</pre>
</p>
</details>
</p>
</details>

Локальная версия в wpt показала интересные результаты: она не всегда быстрее, нужно подбирать wpt. Осталось понять, как его правильно подбирать (пока что выглядит будто наилучший wpt лежит где-то в районе корня от ts), но вопрос остается открытым

<details><summary>Вывод Github CI</summary><p>

<details>
<summary>Matrix transpose</summary>
<p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0151457+-6.92119e-05 s
    GPU: 1107.72 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0303946+-9.98353e-05 s
    GPU: 551.979 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0305046+-0.00015966 s
    GPU: 549.989 millions/s
</pre>
</p>
</details>

<details>
<summary>Matrix multiplication</summary>
<p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.25877+-0 s
CPU: 0.319552 GFlops
[naive, ts=4]
    GPU: 0.331888+-0.0125047 s
    GPU: 6.02613 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.374008+-0.0243176 s
    GPU: 5.34748 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.334829+-0.00200171 s
    GPU: 5.9732 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.575092+-0.00118489 s
    GPU: 3.4777 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.148295+-0.000199817 s
    GPU: 13.4867 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0905535+-0.000222053 s
    GPU: 22.0864 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.509953+-0.000473842 s
    GPU: 3.92193 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.456517+-0.000836954 s
    GPU: 4.381 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.128248+-0.000291944 s
    GPU: 15.5948 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.120781+-0.000401854 s
    GPU: 16.5589 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.15087+-0.000396515 s
    GPU: 13.2565 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0780725+-0.000153636 s
    GPU: 25.6172 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0687968+-0.000110134 s
    GPU: 29.0711 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0853085+-0.000555992 s
    GPU: 23.4443 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0923997+-0.000274222 s
    GPU: 21.6451 GFlops
    Average difference: 0.000149043%
</pre>
</p>
</details>
</p></details>
