### PR TITLE
Task04 Дениль Шарипов СПбГУ

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,106 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(
+    __global const float* a,
+    __global const float* b,
+    __global       float* c,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; k++) {
+        sum += a[j * K + k] * b[k * N + i];
+    }
+    c[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(
+    __global const float* a,
+    __global const float* b,
+    __global       float* c,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N)
 {
-    // TODO
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    int i = get_group_id(0) * TILE_SIZE + local_i;
+    int j = get_group_id(1) * TILE_SIZE + local_j;
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+    for (int tileK = 0; tileK * TILE_SIZE < K; tileK++) {
+        int ii = tileK * TILE_SIZE + local_i;
+        int jj = tileK * TILE_SIZE + local_j;
+
+        tileA[local_j][local_i] = a[j * K + ii];
+        tileB[local_j][local_i] = b[jj * N + i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    c[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(
+     __global const float* a,
+    __global const float* b,
+    __global       float* c,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N)
 {
-    // TODO
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    int i = get_group_id(0) * TILE_SIZE + local_i;
+    int j = get_group_id(1) * TILE_SIZE + local_j;
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        sum[w] = 0.0f;
+    }
+
+    int RTS = TILE_SIZE / WORK_PER_THREAD;
+
+    for (int tileK = 0; tileK * TILE_SIZE < K; tileK++) {
+        int ii = tileK * TILE_SIZE + local_i;
+        int jj = tileK * TILE_SIZE + local_j;
+
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            tileA[local_j + w * RTS][local_i] = a[(j + w * RTS) * K + ii];
+            tileB[local_j + w * RTS][local_i] = b[(jj + w * RTS) * N + i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            for (int w = 0; w < WORK_PER_THREAD; w++) {
+                sum[w] += tileA[local_j + w * RTS][k] * tileB[k][local_i];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        c[(j + w * RTS) * N + i] = sum[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,50 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_naive(__global const float* a, __global float* at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    at[j * k + i] = a[i * m + j];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+__kernel void matrix_transpose_local_bad_banks(__global const float* a, __global float* at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int i_res = get_group_id(0) * TILE_SIZE + local_j;
+    int j_res = get_group_id(1) * TILE_SIZE + local_i;
+    at[i_res * m + j_res] = tile[local_i][local_j];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(__global const float* a, __global float* at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int i_res = get_group_id(0) * TILE_SIZE + local_j;
+    int j_res = get_group_id(1) * TILE_SIZE + local_i;
+    at[i_res * m + j_res] = tile[local_i][local_j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, N, M);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, N, M);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, N, M / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +139,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -27,17 +27,9 @@ void runTest(const std::string &kernel_name, const float *as)
 
     timer t;
     for (int iter = 0; iter < benchmarkingIters; ++iter) {
-        // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
-        // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
-        // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
-        // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
-        // - для 1D, 2D и 3D рабочего пространства соответственно
-
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
-
-        t.nextLap();
+       gpu::WorkSize work_size(16, 16, K, M);
+       matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+       t.nextLap();
     }
 
     std::cout << "[" << kernel_name << "]" << std::endl;
@@ -73,9 +65,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
Транспонирование:
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0041191+-0.000164443 s
    GPU: 4073.03 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.00494767+-0.000149292 s
    GPU: 3390.93 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.00492392+-0.000153312 s
    GPU: 3407.29 millions/s
</pre>

Перемножение матриц:
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.15988+-0 s
CPU: 0.324681 GFlops
[naive, ts=4]
    GPU: 0.0162388+-0.000108884 s
    GPU: 123.162 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.0162183+-7.63188e-05 s
    GPU: 123.317 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.0162235+-9.44806e-05 s
    GPU: 123.278 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.097943+-0.00159655 s
    GPU: 20.42 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.0267002+-0.000120177 s
    GPU: 74.9059 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0143822+-4.1164e-05 s
    GPU: 139.061 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.0787602+-0.00089646 s
    GPU: 25.3935 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.0623238+-0.001387 s
    GPU: 32.0905 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.0243787+-0.000202512 s
    GPU: 82.0389 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.0239863+-0.000257668 s
    GPU: 83.3808 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.0230412+-0.000187661 s
    GPU: 86.8012 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0115895+-0.000271081 s
    GPU: 172.57 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0118172+-8.17851e-05 s
    GPU: 169.245 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0120317+-0.000103937 s
    GPU: 166.228 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0128135+-0.000197784 s
    GPU: 156.085 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
Транспонирование:
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0177306+-0.00139622 s
    GPU: 946.229 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0136139+-3.70603e-05 s
    GPU: 1232.36 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.014062+-4.96258e-05 s
    GPU: 1193.09 millions/s
</pre>

Перемножение матриц:
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.25941+-0 s
CPU: 0.319519 GFlops
[naive, ts=4]
    GPU: 0.252564+-0.00510107 s
    GPU: 7.9188 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.265299+-0.00488805 s
    GPU: 7.53865 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.271116+-0.00541108 s
    GPU: 7.37691 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.588261+-0.00120048 s
    GPU: 3.39985 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.1492+-0.000351727 s
    GPU: 13.4048 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.089536+-0.000184826 s
    GPU: 22.3374 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.518636+-0.000477089 s
    GPU: 3.85627 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.442778+-0.000888885 s
    GPU: 4.51694 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.133551+-0.000344375 s
    GPU: 14.9755 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.157711+-0.000298922 s
    GPU: 12.6814 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.149277+-0.000235859 s
    GPU: 13.3979 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0766538+-0.000217528 s
    GPU: 26.0913 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0820185+-9.12191e-05 s
    GPU: 24.3847 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0794788+-0.00087336 s
    GPU: 25.1639 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0854737+-0.000624424 s
    GPU: 23.399 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>

Проанализируем результаты.
1) Наивное транспонирование матриц работает быстрее всего, возможно потому что кернел запускался на CPU и оптимизация с локальной памятью там ничего не дает. По этой же причине примерно одинаковы результаты кернелов matrix_transpose_local_bad_banks и matrix_transpose_local_good_banks, не понятно, имеет ли место проблема bank conflict на CPU.
2) Сразу можно заметить, что во всех ненаивных реализациях матричного умножения перфоманс увеличивался с увеличением размера тайла. Это можно объяснить тем, что с увеличением размера уменьшается количество синхронизаций, а также уменьшается число простаивающих потоков (то есть увеличивается occupancy). Лучше всего себя показало решение с work per thread с параметрами ts=16, wpt=2. Что интересно, при ts=16 с увеличением wpt перфоманс даже немного падает. Видимо это связано с тем, что есть некоторый трейдофф между количеством работы на поток и конкурентными обращениями к локальной памяти: важно найти золотую середину, чтобы потоки не выполняли слишком много работы и чтобы слишком много потоков не ломились в локальную память. Скорее всего wpt=2 является таким оптимумом и выше поднимать нет смысла. Также интересно почему оптимизации с локальной памятью на CPU вообще давали выигрыш относительно наивной реализации. Я думаю, это связано с тем что реализации с локальной памятью более кеш френдли нежели наивная, причем не понятно, имеет ли место проблема коалесного доступа на CPU.