### PR TITLE
Task04 Андрей Гладких ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,85 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(__global const float *A, __global const float *B, __global float *C, const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float sum = 0.0f;
+
+    for (int k = 0; k < K; k++) {
+        sum += A[j * K + k] * B[k * N + i];
+    }
+
+    C[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(__global const float *A, __global const float *B, __global float *C, const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    int i = get_group_id(0) * TILE_SIZE + local_i;
+    int j = get_group_id(1) * TILE_SIZE + local_j;
+
+    float sum = 0.0f;
+
+    for (int tileK = 0; tileK * TILE_SIZE < K; ++tileK) {
+        tileA[local_j][local_i] = A[j * K + (tileK * TILE_SIZE + local_i)];
+        tileB[local_j][local_i] = B[i + N * (tileK * TILE_SIZE + local_j)];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    C[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+
+#define RTS (TILE_SIZE / WORK_PER_THREAD)
+
+__kernel void matrix_multiplication_local_wpt(__global const float *A, __global const float *B, __global float *C, const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    int i = get_group_id(0) * TILE_SIZE + local_i;
+    int j = get_group_id(1) * TILE_SIZE + local_j;
+
+    float sum[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        sum[w] = 0.0f;
+    }
+
+    for (int tileK = 0; tileK * TILE_SIZE < K; ++tileK) {
+
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            tileA[local_j + w * RTS][local_i] = A[(j + w * RTS) * K + (tileK * TILE_SIZE + local_i)];
+            tileB[local_j + w * RTS][local_i] = B[i + N * (tileK * TILE_SIZE + local_j + w * RTS)];        
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            for (int w = 0; w < WORK_PER_THREAD; w++) {
+                sum[w] += tileA[local_j + w * RTS][k] * tileB[k][local_i];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        C[(j + w * RTS) * N + i] = sum[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,57 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+__kernel void matrix_transpose_naive(__global float *A, __global float *B, const unsigned int M, const unsigned int K)
 {
-    // TODO
+    const unsigned int threadIdX = get_global_id(0);
+    const unsigned int threadIdY = get_global_id(1);
+
+    if (threadIdX >= M || threadIdY >= K) {
+        return;
+    }
+
+    B[threadIdX * K + threadIdY] = A[threadIdY * M + threadIdX];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+#define GROUP_SIZE (32)
+__kernel void matrix_transpose_local_bad_banks(__global float *A, __global float *B, const unsigned int M, const unsigned int K)
 {
-    // TODO
+    __local float block[GROUP_SIZE][GROUP_SIZE];
+
+    const unsigned int threadIdX = get_global_id(0);
+    const unsigned int threadIdY = get_global_id(1);
+    const unsigned int localThreadIdX = get_local_id(0);
+    const unsigned int localThreadIdY = get_local_id(1);
+
+    const unsigned int groupIdX = get_group_id(0);
+    const unsigned int groupIdY = get_group_id(1);
+
+    block[localThreadIdY][localThreadIdX] = A[threadIdY * M + threadIdX];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    
+    const unsigned int x = groupIdY * GROUP_SIZE + localThreadIdX;
+    const unsigned int y = groupIdX * GROUP_SIZE + localThreadIdY;
+    B[y * K + x] = block[localThreadIdX][localThreadIdY];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(__global float *A, __global float *B, const unsigned int M, const unsigned int K)
 {
-    // TODO
+        __local float block[GROUP_SIZE][GROUP_SIZE + 1];
+
+    const unsigned int threadIdX = get_global_id(0);
+    const unsigned int threadIdY = get_global_id(1);
+    const unsigned int localThreadIdX = get_local_id(0);
+    const unsigned int localThreadIdY = get_local_id(1);
+
+    const unsigned int groupIdX = get_group_id(0);
+    const unsigned int groupIdY = get_group_id(1);
+
+    block[localThreadIdY][localThreadIdX] = A[threadIdY * M + threadIdX];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    
+    const unsigned int x = groupIdY * GROUP_SIZE + localThreadIdX;
+    const unsigned int y = groupIdX * GROUP_SIZE + localThreadIdY;
+    B[y * K + x] = block[localThreadIdX][localThreadIdY];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,9 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    const unsigned int groupSize = 16;
+    gpu::WorkSize work_size(groupSize, groupSize, M, K);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +60,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, K);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +69,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, K / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -109,7 +107,7 @@ void runTest(const KernelConfig &config, const float *as, const float *bs, const
     for (int i = 0; i < M * N; ++i) {
         double a = cs[i];
         double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
+        if (a != 0.0 || b != 0.0) { 
             double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
             diff_sum += diff;
         }
@@ -142,9 +140,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -51,7 +51,7 @@ struct KernelConfig {
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
     std::string kernel_name = "matrix_multiplication_naive";
-    const unsigned int groupSize = 32;
+    const unsigned int groupSize = 16;
     gpu::WorkSize work_size(groupSize, groupSize, M, K);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -51,7 +51,7 @@ struct KernelConfig {
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
     std::string kernel_name = "matrix_multiplication_naive";
-    const unsigned int groupSize = 16;
+    const unsigned int groupSize = 32;
     gpu::WorkSize work_size(groupSize, groupSize, M, K);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -34,8 +34,9 @@ void runTest(const std::string &kernel_name, const float *as)
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
         // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        const unsigned int groupSize = 32;
+        gpu::WorkSize work_size(groupSize, groupSize, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +74,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -34,7 +34,7 @@ void runTest(const std::string &kernel_name, const float *as)
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
         // TODO uncomment
-        const unsigned int groupSize = 32;
+        const unsigned int groupSize = 16;
         gpu::WorkSize work_size(groupSize, groupSize, M, K);
         matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 


### PR DESCRIPTION
<details><summary>Локальный вывод (Transpose)</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) Arc(TM) Graphics. Total memory: 16762 Mb
  Device #1: CPU. Intel(R) Core(TM) Ultra 7 155H. Intel(R) Corporation. Total memory: 32125 Mb
Using device #0: GPU. Intel(R) Arc(TM) Graphics. Total memory: 16762 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00377128+-0.00019877 s
    GPU: 4448.68 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.00195015+-2.55094e-05 s
    GPU: 8603.04 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.00196052+-4.55593e-05 s
    GPU: 8557.55 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI (Transpose)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.015259+-0.000113392 s
    GPU: 1099.5 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0132855+-6.97353e-05 s
    GPU: 1262.82 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.013537+-3.64193e-05 s
    GPU: 1239.36 millions/s
</pre>

</p></details>

<details><summary>Комментарий к Transpose</summary><p>

Видно, что наивная реализация проигрывает реализации с использованием локальной памяти почти в два раза. При этом выигрыш от решения проблемы банк конфликтов не очень большой. Но на билд машине не такая большая - возможно, драйвер АМД лучше справляется с оптимизацией наивного подхода. Я протестировал своё решение на домашнем ПК с видеокартой Nvidia - там также драйвер лучше оптимизировал код наивной реализации, результаты были похожи на те, что были получены на билд машине.

<details><summary>Локальный вывод (Transpose) на домашнем ПК с Nvidia</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800X 8-Core Processor             . Intel(R) Corporation. Total memory: 32670 Mb
  Device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Using device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.000253483+-5.92591e-06 s
    GPU: 66186.7 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.000236667+-4.3538e-06 s
    GPU: 70889.6 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0002346+-4.38634e-06 s
    GPU: 71514.1 millions/s
</pre>

</p></details>

</p></details>




<details><summary>Локальный вывод (Multiplication)</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) Arc(TM) Graphics. Total memory: 16762 Mb
  Device #1: CPU. Intel(R) Core(TM) Ultra 7 155H. Intel(R) Corporation. Total memory: 32125 Mb
Using device #0: GPU. Intel(R) Arc(TM) Graphics. Total memory: 16762 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 5.6527+-0 s
CPU: 0.353813 GFlops
[naive, ts=4]
    GPU: 0.0129298+-0.00506418 s
    GPU: 154.681 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.00982067+-0.000204052 s
    GPU: 203.652 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.0230945+-0.00504096 s
    GPU: 86.6007 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.0246667+-0.00320453 s
    GPU: 81.0811 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.0082265+-0.000526315 s
    GPU: 243.117 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.00680717+-0.000545681 s
    GPU: 293.808 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.0304447+-0.000772071 s
    GPU: 65.693 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.0397782+-0.00102341 s
    GPU: 50.2788 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.00601867+-2.58951e-05 s
    GPU: 332.3 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.0249075+-0.00399959 s
    GPU: 80.2971 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.0238167+-0.00370764 s
    GPU: 83.9748 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.0048525+-3.46254e-05 s
    GPU: 412.159 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.00420483+-0.000152785 s
    GPU: 475.643 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.006613+-0.000326825 s
    GPU: 302.435 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.0209527+-0.00349998 s
    GPU: 95.4532 GFlops
    Average difference: 0.000196008%
</pre>

</p></details>

<details><summary>Вывод Github CI (Multiplication)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.27004+-0 s
CPU: 0.318977 GFlops
[naive, ts=4]
    GPU: 0.261326+-0.00506994 s
    GPU: 7.65328 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.272474+-0.00155127 s
    GPU: 7.34016 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.266832+-0.0110931 s
    GPU: 7.49536 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.583692+-0.0133991 s
    GPU: 3.42646 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.146235+-0.000153757 s
    GPU: 13.6766 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0905143+-0.000105533 s
    GPU: 22.0959 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.525954+-0.000970788 s
    GPU: 3.80261 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.445906+-0.0016619 s
    GPU: 4.48525 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.133783+-0.000200853 s
    GPU: 14.9495 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.158151+-0.000265914 s
    GPU: 12.6462 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.154022+-0.000600179 s
    GPU: 12.9852 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0766113+-0.000290652 s
    GPU: 26.1058 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0827903+-0.000156217 s
    GPU: 24.1574 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0789763+-0.000408511 s
    GPU: 25.324 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0916835+-0.000844428 s
    GPU: 21.8142 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>

<details><summary>Комментарий к Multiplication</summary><p>

Наивная реализация ожидаемо, показала плохие результаты из-за плохого паттерна работы с памятью. При этом, что интересно, версия с локальной памятью и tile size 4 оказалась хуже, чем наивная - возможно, барьеры в данном случае оказывали бОльшее влияние, чем задержки обращения к глобальной памяти. При этом при увеличинии tile size данный метод стал заметно обгонять наивную реализацию.

Метод с локальной памятью с увеличинным числом работы на тред показал интересные результаты - наиболее удачным значением work per thread является максимально близкое значение к корню из tile size. При этом есть тенденция, что если увеличивать work per thread, то производительность в среднем ухудшается. Скорее всего это связано с количеством работающих тредов - получается, что выгоднее запускать больше тредов, но с меньшим количеством работы на тред.

</p></details>