### PR TITLE
Task04 Артем Сидоренко HSE

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,5 +1,7 @@
 #ifdef __CLION_IDE__
-    #include <libgpu/opencl/cl/clion_defines.cl>
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 
@@ -7,21 +9,83 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
-{
-    // TODO
+__kernel void
+matrix_multiplication_naive(__global float *as, __global float *bs, __global float *cs, unsigned int M, unsigned int K,
+                            unsigned int N) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float sum = 0.f;
+    for (int k = 0; k < K; k++) {
+        sum += as[i * K + k] * bs[k * N + j];
+    }
+    cs[i * N + j] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
-{
-    // TODO
+__kernel void
+matrix_multiplication_local(__global float *as, __global float *bs, __global float *cs, unsigned int M, unsigned int K,
+                            unsigned int N) {
+    int gi = get_global_id(0);
+    int gj = get_global_id(1);
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    __local float tile_as[TILE_SIZE][TILE_SIZE];
+    __local float tile_bs[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.f;
+    for (int tile_k = 0; tile_k * TILE_SIZE < K; tile_k++) {
+        tile_as[li][lj] = as[gi * K + lj + (tile_k * TILE_SIZE)];
+        tile_bs[li][lj] = bs[(li + (tile_k * TILE_SIZE)) * N + gj];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int t = 0; t < TILE_SIZE; t++) {
+            sum += tile_as[li][t] * tile_bs[t][lj];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    cs[gi * N + gj] = sum;
 }
+
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
-{
-    // TODO
+__kernel void
+matrix_multiplication_local_wpt(__global float *as, __global float *bs, __global float *cs, unsigned int M,
+                                unsigned int K,
+                                unsigned int N) {
+    int gi = get_global_id(0);
+    int gj = get_global_id(1);
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    __local float tile_as[TILE_SIZE][TILE_SIZE];
+    __local float tile_bs[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD] = {0.f};
+    for (int tile_k = 0; tile_k * TILE_SIZE < K; tile_k++) {
+        for (int wi = 0; wi < WORK_PER_THREAD; wi++) {
+
+            tile_as[li * WORK_PER_THREAD + wi][lj] = as[(gi * WORK_PER_THREAD + wi) * K + lj +
+                                                        (tile_k * TILE_SIZE)];
+            tile_bs[li * WORK_PER_THREAD + wi][lj] = bs[((li * WORK_PER_THREAD + wi) + (tile_k * TILE_SIZE)) * N +
+                                                        gj];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int wi = 0; wi < WORK_PER_THREAD; wi++) {
+            for (int t = 0; t < TILE_SIZE; t++) {
+                sum[wi] += tile_as[li * WORK_PER_THREAD + wi][t] * tile_bs[t][lj];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+    }
+    for (int wi = 0; wi < WORK_PER_THREAD; wi++) {
+        cs[(gi * WORK_PER_THREAD + wi) * N + gj] = sum[wi];
+    }
 }
+
 #endif

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -17,9 +17,9 @@ matrix_multiplication_naive(__global float *as, __global float *bs, __global flo
 
     float sum = 0.f;
     for (int k = 0; k < K; k++) {
-        sum += as[i * K + k] * bs[k * N + j];
+        sum += as[j * K + k] * bs[k * N + i];
     }
-    cs[i * N + j] = sum;
+    cs[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
@@ -36,30 +36,32 @@ matrix_multiplication_local(__global float *as, __global float *bs, __global flo
 
     float sum = 0.f;
     for (int tile_k = 0; tile_k * TILE_SIZE < K; tile_k++) {
-        tile_as[li][lj] = as[gi * K + lj + (tile_k * TILE_SIZE)];
-        tile_bs[li][lj] = bs[(li + (tile_k * TILE_SIZE)) * N + gj];
+        tile_as[lj][li] = as[gj * K + li + (tile_k * TILE_SIZE)];
+        tile_bs[lj][li] = bs[(lj + (tile_k * TILE_SIZE)) * N + gi];
 
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (int t = 0; t < TILE_SIZE; t++) {
-            sum += tile_as[li][t] * tile_bs[t][lj];
+            sum += tile_as[lj][t] * tile_bs[t][li];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
     }
-    cs[gi * N + gj] = sum;
+    cs[gj * N + gi] = sum;
 }
 
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
+
+#define RTS (TILE_SIZE / WORK_PER_THREAD)
 __kernel void
 matrix_multiplication_local_wpt(__global float *as, __global float *bs, __global float *cs, unsigned int M,
                                 unsigned int K,
                                 unsigned int N) {
-    int gi = get_global_id(0);
-    int gj = get_global_id(1);
     int li = get_local_id(0);
     int lj = get_local_id(1);
+    int gi = TILE_SIZE * get_group_id(0) + li;
+    int gj = TILE_SIZE * get_group_id(1) + lj;
 
     __local float tile_as[TILE_SIZE][TILE_SIZE];
     __local float tile_bs[TILE_SIZE][TILE_SIZE];
@@ -67,24 +69,23 @@ matrix_multiplication_local_wpt(__global float *as, __global float *bs, __global
     float sum[WORK_PER_THREAD] = {0.f};
     for (int tile_k = 0; tile_k * TILE_SIZE < K; tile_k++) {
         for (int wi = 0; wi < WORK_PER_THREAD; wi++) {
-
-            tile_as[li * WORK_PER_THREAD + wi][lj] = as[(gi * WORK_PER_THREAD + wi) * K + lj +
-                                                        (tile_k * TILE_SIZE)];
-            tile_bs[li * WORK_PER_THREAD + wi][lj] = bs[((li * WORK_PER_THREAD + wi) + (tile_k * TILE_SIZE)) * N +
-                                                        gj];
+            int tile_i = TILE_SIZE * tile_k + li;
+            int tile_j = TILE_SIZE * tile_k + lj;
+            tile_as[lj + wi * RTS][li] = as[(gj + wi * RTS) * K + tile_i];
+            tile_bs[lj + wi * RTS][li] = bs[(tile_j + wi * RTS) * N + gi];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (int wi = 0; wi < WORK_PER_THREAD; wi++) {
             for (int t = 0; t < TILE_SIZE; t++) {
-                sum[wi] += tile_as[li * WORK_PER_THREAD + wi][t] * tile_bs[t][lj];
+                sum[wi] += tile_as[lj + RTS * wi][t] * tile_bs[t][li];
             }
         }
         barrier(CLK_LOCAL_MEM_FENCE);
 
     }
     for (int wi = 0; wi < WORK_PER_THREAD; wi++) {
-        cs[(gi * WORK_PER_THREAD + wi) * N + gj] = sum[wi];
+        cs[(gj + wi * RTS) * N + gi] = sum[wi];
     }
 }
 

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -28,7 +28,15 @@ __kernel void matrix_transpose_local_bad_banks(__global float *as,
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    as_t[gi * h + gj] = tile[li][lj];
+    // mirroring over tile main diag
+    // (x1,y1) = (li,lj) in old tile
+    // (x2,y2) = (lj,li) in new tile
+    // (x1-x2, y1-y2) = (li-lj, lj-li) is shift
+    // axis swapped in transposed
+    // so new coords increase over col, then over row (like initial, so we have coalesced access)
+    int gj_t = gi - (li - lj);
+    int gi_t = gj - (lj - li);
+    as_t[gj_t * w + gi_t] = tile[lj][li];
 }
 
 __kernel void matrix_transpose_local_good_banks(__global float *as,
@@ -36,13 +44,24 @@ __kernel void matrix_transpose_local_good_banks(__global float *as,
     int gi = get_global_id(0);
     int gj = get_global_id(1);
 
-    __local float tile[TILE_SIZE][TILE_SIZE];
+    // with just 1 extra element in each row we get bank index (li + lj) % 32 for elem on (li, lj) and TILESIZE=32
+    // both elems for each thread is in one bank (if 32 banks total)
+    // KPACUBO)
+    __local float tile[TILE_SIZE + 1][TILE_SIZE];
     int li = get_local_id(0);
     int lj = get_local_id(1);
 
-    tile[lj][li] = as[gj * w + gi];
+    tile[li][lj] = as[gj * w + gi];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    as_t[gi * h + gj] = tile[lj][li];
+    // mirroring over tile main diag
+    // (x1,y1) = (li,lj) in old tile
+    // (x2,y2) = (lj,li) in new tile
+    // (x1-x2, y1-y2) = (li-lj, lj-li) is shift
+    // axis swapped in transposed
+    // so new coords increase over col, then over row (like initial, so we have coalesced access)
+    int gj_t = gi - (li - lj);
+    int gi_t = gj - (lj - li);
+    as_t[gj_t * w + gi_t] = tile[lj][li];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,21 +1,48 @@
 #ifdef __CLION_IDE__
-    #include <libgpu/opencl/cl/clion_defines.cl>
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 
 #line 6
 
-__kernel void matrix_transpose_naive()
-{
-    // TODO
+__kernel void matrix_transpose_naive(__global float *as,
+                                     __global float *as_t, unsigned int w, unsigned int h) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    as_t[i * h + j] = as[j * w + i];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+#define TILE_SIZE 32
+__kernel void matrix_transpose_local_bad_banks(__global float *as,
+                                               __global float *as_t, unsigned int w, unsigned int h) {
+    int gi = get_global_id(0);
+    int gj = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    tile[li][lj] = as[gj * w + gi];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[gi * h + gj] = tile[li][lj];
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_good_banks(__global float *as,
+                                                __global float *as_t, unsigned int w, unsigned int h) {
+    int gi = get_global_id(0);
+    int gj = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    tile[lj][li] = as[gj * w + gi];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[gi * h + gj] = tile[lj][li];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -47,7 +47,7 @@ __kernel void matrix_transpose_local_good_banks(__global float *as,
     // with just 1 extra element in each row we get bank index (li + lj) % 32 for elem on (li, lj) and TILESIZE=32
     // both elems for each thread is in one bank (if 32 banks total)
     // KPACUBO)
-    __local float tile[TILE_SIZE + 1][TILE_SIZE];
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
     int li = get_local_id(0);
     int lj = get_local_id(1);
 

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -69,7 +69,7 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(tile_size / wpt, tile_size, M / wpt, N);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size / wpt, tile_size, M / wpt, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -141,10 +138,18 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
-    const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
+//    std::cout << "As data: {";
+//    for (auto a : as) std::cout << a << ", ";
+//    std::cout << "}" << std::endl;
+//
+//    std::cout << "Bs data: {";
+//    for (auto b : bs) std::cout << b << ", ";
+//    std::cout << "}" << std::endl;
 
-    // TODO uncomment
-    return 0;
+    const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
+//    std::cout << "Cs data: {";
+//    for (auto c : cs_cpu_reference) std::cout << c << ", ";
+//    std::cout << "}" << std::endl;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -34,8 +34,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
         // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(16, 16, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +73,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\matrix_transpose.exe 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.000766667+-0.000422953 s
    GPU: 21883.3 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.000866667+-0.000339935 s
    GPU: 19358.3 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000483333+-0.000499722 s
    GPU: 34711.5 millions/s

Process finished with exit code 0
</pre>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\matrix_multiplication.exe 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 5.91+-0 s
CPU: 0.338409 GFlops
[naive, ts=4]
    GPU: 0.0143333+-0.000471405 s
    GPU: 139.535 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.005+-0 s
    GPU: 400 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.00916667+-0.000372678 s
    GPU: 218.182 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.012+-1.64636e-10 s
    GPU: 166.667 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.00366667+-0.000471405 s
    GPU: 545.455 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.005+-0 s
    GPU: 400 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.0128333+-0.000372678 s
    GPU: 155.844 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.015+-0 s
    GPU: 133.333 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.00283333+-0.000372678 s
    GPU: 705.882 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.00266667+-0.000471405 s
    GPU: 750 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.004+-0 s
    GPU: 500 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.006+-8.23181e-11 s
    GPU: 333.333 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.003+-4.1159e-11 s
    GPU: 666.667 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.00116667+-0.000372678 s
    GPU: 1714.29 GFlops
    Average difference: 0.000196008%

Process finished with exit code 0

</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./matrix_transpose
        OpenCL devices:
Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
        Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
        Data generated for M=4096, K=4096
[matrix_transpose_naive]
GPU: 0.015364+-7.13654e-05 s
        GPU: 1091.98 millions/s
[matrix_transpose_local_bad_banks]
GPU: 0.0305598+-0.000536771 s
        GPU: 548.996 millions/s
[matrix_transpose_local_good_banks]
GPU: 0.0275652+-0.000553217 s
        GPU: 608.639 millions/s
</pre>

<pre>
Run ./matrix_multiplication
        OpenCL devices:
Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
        Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
        Data generated for M=1024, K=1024, N=1024
CPU: 6.12743+-0 s
        CPU: 0.326401 GFlops
[naive, ts=4]
GPU: 0.391487+-0.00513373 s
        GPU: 5.10873 GFlops
        Average difference: 0.000149043%
[naive, ts=8]
GPU: 0.374315+-0.013916 s
        GPU: 5.3431 GFlops
        Average difference: 0.000149043%
[naive, ts=16]
GPU: 0.379281+-0.00390148 s
        GPU: 5.27313 GFlops
        Average difference: 0.000149043%
[local, ts=4]
GPU: 0.553736+-0.00103241 s
        GPU: 3.61183 GFlops
        Average difference: 0.000149043%
[local, ts=8]
GPU: 0.317307+-0.0058429 s
        GPU: 6.30304 GFlops
        Average difference: 0.000149043%
[local, ts=16]
GPU: 0.284326+-0.00166251 s
        GPU: 7.03418 GFlops
        Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
GPU: 0.51959+-0.0018257 s
        GPU: 3.84919 GFlops
        Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
GPU: 0.440409+-0.00201381 s
        GPU: 4.54123 GFlops
        Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
GPU: 0.316695+-0.0018561 s
        GPU: 6.31523 GFlops
        Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
GPU: 0.285732+-0.00208471 s
        GPU: 6.99957 GFlops
        Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
GPU: 0.269433+-0.000393289 s
        GPU: 7.423 GFlops
        Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
GPU: 0.237836+-0.00111567 s
        GPU: 8.40917 GFlops
        Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
GPU: 0.230737+-0.000713002 s
        GPU: 8.66786 GFlops
        Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
GPU: 0.192883+-0.00156463 s
        GPU: 10.369 GFlops
        Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
GPU: 0.185014+-0.00170034 s
        GPU: 10.81 GFlops
        Average difference: 0.000149043%
</pre>

</p></details>

Транспонирование: на честной гпу локальная память с конфликтами показала первофанс хуже чем наивная версия. Зато если поменять индексы в локальной памяти местами, то получается буст в 60-70 процентов). А вот на цпу наивный вариант оказался самым производительным (на сервере это лучше видно, локально у меня там ~ одинаковые числа). 

Произведение: тут на честной гпу оптимизации с памятью конечно взяли свое (хотя у меня там подозрительно ровные флопсы получались из раза в раз). Самым быстрым оказался вариант с ts=16 и wpt=8. 
Но я здесь не доделал чутка -- не проверил разбиение по другой оси (по столбцам вместо строк) + возможно у меня там bank conflicts есть