### PR TITLE
Task04 Даниил Русов ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,98 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N) 
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k)
+    {
+        sum += a[j* K+ k] * b[k* N + i];
+    }
+
+    c[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(__global float *a, __global float *b, global float *c, unsigned int M, unsigned int K, unsigned int N) 
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+    for (int tileK = 0; tileK * TILE_SIZE < K; ++tileK) 
+    {
+        tileA[local_j][local_i] = a[j * K + tileK * TILE_SIZE + local_i];
+        tileB [local_j][local_i] = b[N * (tileK * TILE_SIZE + local_j) + i];
+        barrier(CLK_LOCAL_MEM_FENCE);
+        for (int k = 0; k < TILE_SIZE; k++)
+        {
+        sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    c[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N) 
 {
-    // TODO
+    const int local_i = get_local_id(0);
+    const int local_j = get_local_id(1) * WORK_PER_THREAD;
+    const int i = TILE_SIZE * get_group_id(0) + local_i;
+    const int j = TILE_SIZE * get_group_id(1) + local_j;
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float acc[WORK_PER_THREAD];
+    for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
+        acc[w] = 0.0f;
+    }
+
+    const int numTiles = K / TILE_SIZE;
+    const int RTS = TILE_SIZE / WORK_PER_THREAD;
+
+    for (int t = 0; t < numTiles; t++) 
+    {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            if (i < N && j < M && t + local_i < K) {
+                tileA[local_j + w][local_i] = a[t*TILE_SIZE + local_i + K * (j + w)];
+            }
+            else
+            {
+                tileA[local_j + w][local_i] =  0.f;
+            }
+            if (i < N && j < M && t + local_i < K) {
+                tileB[local_j + w][local_i] = b[i + N * (t*TILE_SIZE + local_j + w)];
+            }
+            else
+            {
+                tileB[local_j + w][local_i] =  0.f;
+            }
+        }
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+ 
+        for (int k = 0; k < TILE_SIZE; k++) {
+            for (int w = 0; w < WORK_PER_THREAD; w++) {
+                acc[w] += tileA[local_j + w][k] * tileB[k][local_i];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) 
+    {
+        c[(j + w) * N + i] = acc[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,47 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_naive(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    float x=a[j * k + i];
+    at[i * m + j] = x;
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+
+
+__kernel void matrix_transpose_local_bad_banks(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int local_i = get_local_id (0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[i * m + j] = tile[local_j][local_i];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+
+__kernel void matrix_transpose_local_good_banks(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE + 1][TILE_SIZE];
+    int local_i = get_local_id (0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[i * m + j] = tile[local_j][local_i];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -30,7 +30,10 @@ __kernel void matrix_transpose_local_bad_banks(__global float *a, __global float
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    at[i * m + j] = tile[local_j][local_i];
+    int tile_i = get_group_id(0) * TILE_SIZE;
+    int tile_j = get_group_id(1) * TILE_SIZE;
+
+    at[(tile_i + local_j) * m + (tile_j + local_i)] = tile[local_i][local_j];
 }
 
 
@@ -39,7 +42,7 @@ __kernel void matrix_transpose_local_good_banks(__global float *a, __global floa
     int i = get_global_id(0);
     int j = get_global_id(1);
 
-    __local float tile[TILE_SIZE + 1][TILE_SIZE];
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
     int local_i = get_local_id (0);
     int local_j = get_local_id(1);
 
@@ -47,5 +50,8 @@ __kernel void matrix_transpose_local_good_banks(__global float *a, __global floa
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    at[i * m + j] = tile[local_j][local_i];
+    int tile_i = get_group_id(0) * TILE_SIZE;
+    int tile_j = get_group_id(1) * TILE_SIZE;
+
+    at[(tile_i + local_j) * m + (tile_j + local_i)] = tile[local_i][local_j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +139,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -33,9 +33,9 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        const unsigned int group_size = 16;
+        gpu::WorkSize work_size(group_size, group_size, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +73,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
Для транспонирования есть стабильное улучшение при использовании локальной памяти, между версиями с разным использованием банков разницы почти нет.

<details><summary>Локальный вывод Transpose</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16011 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6404 Mb
  Device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
Using device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00085+-0.000357071 s
    GPU: 19737.9 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.00075+-0.000433013 s
    GPU: 22369.6 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000716667+-0.000450617 s
    GPU: 23410.1 millions/s
</pre>
</p></details>


<details><summary>Вывод Github CI Transpose</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0152023+-6.03511e-05 s
    GPU: 1103.6 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0269111+-0.00037625 s
    GPU: 623.431 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0275094+-0.000476693 s
    GPU: 609.873 millions/s
</pre>
</p></details>


Во всех трех реализациях умножения матриц tile_size увеличивает скорость. Увеличение work per thread почти всегда замедляет обработку, кроме случая с ts=16, wpt=4 быстрее, чем wpt=2. 
Кажется, что ускорение с wpt работает до определенного лимита, зависящего от ts: 
- с ts=4 wpt уменьшает скорость относительно local, 
- с ts=8 ускоряет только wpt=2, 
- с ts=16 wpt=2 и wpt=4 ускоряют, дальше замедление. 

Выгодно выбирать максимальный tile_size и находить предел wpt, который не замедляет обработку.

<details><summary>Локальный вывод MatMul</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16011 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6404 Mb
  Device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
Using device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.026+-0 s
CPU: 0.660939 GFlops
[naive, ts=4]
    GPU: 0.0065+-0.0005 s
    GPU: 307.692 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.00316667+-0.000372678 s
    GPU: 631.579 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.003+-4.1159e-11 s
    GPU: 666.667 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.009+-1.16415e-10 s
    GPU: 222.222 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.0025+-0.0005 s
    GPU: 800 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.011+-2.32831e-10 s
    GPU: 181.818 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.0175+-0.0005 s
    GPU: 114.286 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.003+-4.1159e-11 s
    GPU: 666.667 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.005+-0 s
    GPU: 400 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.00116667+-0.000372678 s
    GPU: 1714.29 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.00166667+-0.000471405 s
    GPU: 1200 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.003+-4.1159e-11 s
    GPU: 666.667 GFlops
    Average difference: 0.000196008%
</pre>
</p></details>


<details><summary>Вывод Github CI MatMul</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.29642+-0 s
CPU: 0.317641 GFlops
[naive, ts=4]
    GPU: 0.248826+-0.00371161 s
    GPU: 8.03774 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.263166+-0.0026112 s
    GPU: 7.59976 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.26443+-0.00173557 s
    GPU: 7.56345 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.59817+-0.0022753 s
    GPU: 3.34353 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.146368+-0.000206972 s
    GPU: 13.6642 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0902058+-0.000120555 s
    GPU: 22.1715 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.545463+-0.000431768 s
    GPU: 3.66661 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.463522+-0.00152486 s
    GPU: 4.31479 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.141035+-0.000374669 s
    GPU: 14.1809 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.137356+-0.000349225 s
    GPU: 14.5607 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.13083+-0.000287623 s
    GPU: 15.2871 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.079328+-0.000278888 s
    GPU: 25.2118 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0773073+-0.000271219 s
    GPU: 25.8708 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0809863+-0.000441286 s
    GPU: 24.6955 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0915908+-0.000142025 s
    GPU: 21.8362 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>