### PR TITLE
Task04 Уткин Илья ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -2,26 +2,125 @@
     #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
-
-#line 6
+// I work in vstudio
+// #line 6 
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(
+    __global const float* a,
+    __global const float* b,
+    __global float* c,
+    unsigned int M, 
+    unsigned int K,
+    unsigned int N
+)
 {
-    // TODO
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+
+    float acc = 0.0f;
+    for (int k = 0; k < K; k++) {
+        acc += a[y * K + k] * b[k * N + x];
+    }
+    c[y * N + x] = acc;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(
+    __global const float* a,
+    __global const float* b,
+    __global float* c,
+    unsigned int M, 
+    unsigned int K,
+    unsigned int N
+)
 {
-    // TODO
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+    
+    int local_x = get_local_id(0);
+    int local_y = get_local_id(1);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+    const int numTiles = K / TILE_SIZE;
+    for (int t = 0; t < numTiles; t++) {
+        int x_a = t * TILE_SIZE + local_x;
+        int y_a = y;
+
+        int x_b = x;
+        int y_b = t * TILE_SIZE + local_y;
+
+        tile_a[local_y][local_x] = a[y_a * K + x_a];
+        tile_b[local_y][local_x] = b[y_b * N + x_b];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            sum += tile_a[local_y][k] * tile_b[k][local_x];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    c[y * N + x] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
-{
-    // TODO
+__kernel void matrix_multiplication_local_wpt(
+    __global const float* a,
+    __global const float* b,
+    __global float* c,
+    unsigned int M, 
+    unsigned int K,
+    unsigned int N
+)
+{    
+    int local_x = get_local_id(0);
+    int local_y = get_local_id(1);
+
+    int x = get_group_id(0) * TILE_SIZE + local_x;
+    int y = get_group_id(1) * TILE_SIZE + local_y;
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float reg[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        reg[w] = 0.0f;
+    }
+
+    const int numTiles = K / TILE_SIZE;
+    const int RTS = TILE_SIZE / WORK_PER_THREAD;
+
+    for (int t = 0; t < numTiles; t++) {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            int x_a = t * TILE_SIZE + local_x;
+            int y_a = y + w * RTS;
+        
+            int x_b = x;
+            int y_b = t * TILE_SIZE + local_y + w * RTS;
+            
+            tile_a[local_y + w * RTS][local_x] = a[y_a * K + x_a];
+            tile_b[local_y + w * RTS][local_x] = b[y_b * N + x_b];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            for (int w = 0; w < WORK_PER_THREAD; w++) {
+                reg[w] += tile_a[local_y + w * RTS][k] * tile_b[k][local_x];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        c[(y + w * RTS) * N + x] = reg[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,81 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_naive(
+    __global float* a,
+    __global float* a_t,
+    unsigned int M, unsigned int K
+)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    if (j >= M || i >= K) {
+        return;
+    }
+
+    float x = a[j * K + i];
+    a_t[i * M + j] = x;
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+__kernel void matrix_transpose_local_bad_banks(
+    __global float* a,
+    __global float* a_t,
+    unsigned int M, unsigned int K
+)
 {
-    // TODO
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+
+    if (y >= M || x >= K) {
+        return;
+    }
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int local_x = get_local_id(0);
+    int local_y = get_local_id(1);
+
+    tile[local_y][local_x] = a[y * K + x];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int tile_y_T = get_group_id(1) * TILE_SIZE;
+    int tile_x_T = get_group_id(0) * TILE_SIZE;
+
+    int in_tile_x_T = local_y;
+    int in_tile_y_T = local_x;
+
+    a_t[(tile_x_T + in_tile_x_T) * M + (tile_y_T + in_tile_y_T)] = tile[local_x][local_y];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(
+    __global float* a,
+    __global float* a_t,
+    unsigned int M, unsigned int K
+)
 {
-    // TODO
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+
+    if (y >= M || x >= K) {
+        return;
+    }
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
+    int local_x = get_local_id(0);
+    int local_y = get_local_id(1);
+
+    tile[local_y][local_x] = a[y * K + x];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int tile_y_T = get_group_id(1) * TILE_SIZE;
+    int tile_x_T = get_group_id(0) * TILE_SIZE;
+
+    int in_tile_x_T = local_y;
+    int in_tile_y_T = local_x;
+
+    a_t[(tile_x_T + in_tile_x_T) * M + (tile_y_T + in_tile_y_T)] = tile[local_x][local_y];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, K, M);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, K, M);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, K, M / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +139,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());


### PR DESCRIPTION
Транспонирование
Здесь сильно выигрывает использование локальной памяти, но вот оптимизация доступа к банкам никакой роли не сыграла. Я запускаюсь на цпу, поэтому видимо банки никак не мапятся на устройства ЦПУ, зато кэш мапится

Произведение
Cнова использование локальной памяти сильно улучшает производительность (46.5 gflops vs 20.4 gflops). Использование регистров потока еще сильнее ускоряет исполнение (получилось выжать аж 57 gflops), что намекает на мапинг регистров тредов на регистры самого процессора. Либо на цпу просто мало потоков и ему выгодно не так сильно дробить задачу.