### PR TITLE
Task04 Роман Гостило HSE

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,115 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(
+        __global float *a,
+        __global float *b,
+        __global float *c,
+        unsigned int M,
+        unsigned int K,
+        unsigned int N
+        )
 {
-    // TODO
+    int i = get_global_id(0);   // до N
+    int j = get_global_id(1);   // до M
+
+    float sum = 0.0f;
+
+    for (int k = 0; k < K; k++) {
+        sum += a[j * K + k] * b[k * N + i];
+    }
+
+    c[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(
+        __global float *a,
+        __global float *b,
+        __global float *c,
+        unsigned int M,
+        unsigned int K,
+        unsigned int N
+        )
 {
-    // TODO
+    int i = get_global_id(0);   // до N
+    int j = get_global_id(1);   // до M
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+    for (unsigned int tile_start_i = 0; tile_start_i < K; tile_start_i += TILE_SIZE) {
+        if (tile_start_i + local_i < K && tile_start_i + local_j < K) {
+            tileA[local_j][local_i] = a[j * K + tile_start_i + local_i];
+            tileB[local_j][local_i] = b[(tile_start_i + local_j) * N + i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (unsigned int k = 0; k < TILE_SIZE; k++) {
+            if (tile_start_i + k >= K) {
+                continue;
+            }
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    c[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(
+        __global float *a,
+        __global float *b,
+        __global float *c,
+        unsigned int M,
+        unsigned int K,
+        unsigned int N
+        )
 {
-    // TODO
+    int i = get_global_id(0) * WORK_PER_THREAD;   // до N / wpt
+    int j = get_global_id(1);   // до M
+
+    int local_i = get_local_id(0) * WORK_PER_THREAD; // до N / wpt
+    int local_j = get_local_id(1); // до M
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD];
+
+    for (unsigned int wpt_i = 0; wpt_i < WORK_PER_THREAD; wpt_i++) {
+        sum[wpt_i] = 0.0f;
+    }
+
+    for (unsigned int tile_start_i = 0; tile_start_i < K; tile_start_i += TILE_SIZE) {
+        if (tile_start_i + local_i < K && tile_start_i + local_j < K) {
+            for (unsigned int i_wpt = 0; i_wpt < WORK_PER_THREAD; i_wpt++) {
+                tileA[local_j][local_i + i_wpt] = a[j * K + tile_start_i + (local_i + i_wpt)];
+                tileB[local_j][local_i + i_wpt] = b[(tile_start_i + local_j) * N + i + i_wpt];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (unsigned int k = 0; k < TILE_SIZE; k++) {
+            for (unsigned int wpt_i = 0; wpt_i < WORK_PER_THREAD; wpt_i++) {
+                sum[wpt_i] += tileA[local_j][k] * tileB[k][local_i + wpt_i];;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (unsigned int wpt_i = 0; wpt_i < WORK_PER_THREAD; wpt_i++) {
+         c[j * N + i + wpt_i] = sum[wpt_i];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,21 +1,93 @@
 #ifdef __CLION_IDE__
-    #include <libgpu/opencl/cl/clion_defines.cl>
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 
 #line 6
 
-__kernel void matrix_transpose_naive()
-{
-    // TODO
+#define TILE_SIZE 8
+__kernel void matrix_transpose_naive(
+        __global float *a,
+        __global float *at,
+        unsigned int m,
+        unsigned int k
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    at[i * m + j] = a[j * k + i];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_bad_banks(
+        __global float *a,
+        __global float *at,
+        unsigned int m,
+        unsigned int k
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int tile_i = i - local_i;
+    int tile_j = j - local_j;
+
+    at[(tile_i + local_j) * k + (tile_j + local_i)] = tile[local_i][local_j];
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_bad_banks_from_lecture(
+        __global float *a,
+        __global float *at,
+        unsigned int m,
+        unsigned int k
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // почему "здесь все хорошо с coalesced", если мы все равно загружаем в память по мере изменения j?
+    // я понимаю, что разницы нет, если группа помещается на один варп
+    // но если нет, то мы будем загружать в память вертикальным прямоугольником (а могли бы горизонтальным)
+    at[i * m + j] = tile[local_j][local_i];
+}
+
+
+__kernel void matrix_transpose_local_good_banks(
+        __global float *a,
+        __global float *at,
+        unsigned int m,
+        unsigned int k
+        ) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int tile_i = i - local_i;
+    int tile_j = j - local_j;
+
+    at[(tile_i + local_j) * k + (tile_j + local_i)] = tile[local_i][local_j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(1, 1, N, M);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, N, M);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size / wpt, tile_size, N / wpt, M);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -144,8 +141,8 @@ int main(int argc, char **argv)
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
 
     // TODO uncomment
-    return 0;
 
+    // а какая разница какой tile_size, мы же в наивном реализации его не используем?
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -51,7 +51,7 @@ struct KernelConfig {
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(1, 1, N, M);
+    gpu::WorkSize work_size(tile_size, tile_size, N, M);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -69,7 +69,7 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(tile_size / wpt, tile_size, N / wpt, M);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, N, M / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -33,9 +33,11 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        unsigned int work_group_size = 8;
+        unsigned int global_work_size_x = (M + work_group_size - 1) / work_group_size * work_group_size;
+        unsigned int global_work_size_y = (K + work_group_size - 1) / work_group_size * work_group_size;
+        gpu::WorkSize work_size(work_group_size, work_group_size, global_work_size_x, global_work_size_y);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -53,6 +55,7 @@ void runTest(const std::string &kernel_name, const float *as)
             float a = as[j * K + i];
             float b = as_t[i * M + j];
             if (a != b) {
+                printf("%d != %d", a, b);
                 throw std::runtime_error("Not the same!");
             }
         }
@@ -74,10 +77,8 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    // TODO uncomment
-    return 0;
-
     runTest("matrix_transpose_naive", as.data());
+
     runTest("matrix_transpose_local_bad_banks", as.data());
     runTest("matrix_transpose_local_good_banks", as.data());
 


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb


// transpose
[matrix_transpose_naive]
    GPU: 0.00121673+-6.58247e-05 s
    GPU: 13788.7 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0012724+-2.12196e-05 s
    GPU: 13185.5 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000807067+-2.19984e-05 s
    GPU: 20787.9 millions/s

// multiplication
CPU: 2.14423+-1.14393e-08 s
CPU: 0.932738 GFlops
[naive, ts=4]
    GPU: 0.003414+-0.000104555 s
    GPU: 585.823 GFlops
    Average difference: 0%
[naive, ts=8]
    GPU: 0.00328933+-0.000192186 s
    GPU: 608.026 GFlops
    Average difference: 0%
[naive, ts=16]
    GPU: 0.00321767+-0.00018737 s
    GPU: 621.568 GFlops
    Average difference: 0%
[local, ts=4]
    GPU: 0.009607+-0.000691962 s
    GPU: 208.182 GFlops
    Average difference: 0%
[local, ts=8]
    GPU: 0.00309883+-0.00012401 s
    GPU: 645.404 GFlops
    Average difference: 0%
[local, ts=16]
    GPU: 0.00331283+-2.87832e-05 s
    GPU: 603.713 GFlops
    Average difference: 0%
[local wpt, ts=4, wpt=2]
    GPU: 0.0073185+-0.000125702 s
    GPU: 273.28 GFlops
    Average difference: 0%
[local wpt, ts=4, wpt=4]
    GPU: 0.0104235+-0.000114608 s
    GPU: 191.874 GFlops
    Average difference: 0%
[local wpt, ts=8, wpt=2]
    GPU: 0.001568+-4.56655e-05 s
    GPU: 1275.51 GFlops
    Average difference: 0%
[local wpt, ts=8, wpt=4]
    GPU: 0.002627+-6.84982e-05 s
    GPU: 761.325 GFlops
    Average difference: 0%
[local wpt, ts=8, wpt=8]
    GPU: 0.00395683+-0.000104913 s
    GPU: 505.455 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=2]
    GPU: 0.00134367+-1.59339e-05 s
    GPU: 1488.46 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=4]
    GPU: 0.001696+-4.08616e-05 s
    GPU: 1179.25 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=8]
    GPU: 0.00134417+-1.17957e-05 s
    GPU: 1487.91 GFlops
    Average difference: 0%
[local wpt, ts=16, wpt=16]
    GPU: 0.00184783+-4.05726e-05 s
    GPU: 1082.35 GFlops
    Average difference: 0%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC [7](https://github.com/unicoooorn/GPGPUTasks2024/actions/runs/11203759844/job/31141386198#step:7:8)763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb

// transpose
[naive, ts=4]
    GPU: 0.264217+-0.00211563 s
    GPU: 7.56954 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.275914+-0.0121007 s
    GPU: 7.24864 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.268628+-0.00850799 s
    GPU: 7.44523 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.662698+-0.000845374 s
    GPU: 3.01797 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.134409+-0.00091397 s
    GPU: 14.8799 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.092175+-0.000434754 s
    GPU: 21.6979 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.557298+-0.00080293 s
    GPU: 3.58875 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.454064+-0.00198623 s
    GPU: 4.40466 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.200014+-0.000220297 s
    GPU: 9.99928 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.274665+-0.000292907 s
    GPU: 7.2816 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.262284+-0.0018582 s
    GPU: 7.62532 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.167999+-0.000408106 s
    GPU: 11.9049 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.185181+-0.00037464 s
    GPU: 10.8002 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0831683+-0.00109888 s
    GPU: 24.0476 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0955148+-0.000390703 s
    GPU: 20.9392 GFlops
    Average difference: 0.000149043%

</pre>

</p></details>

transpose:
Я могу ошибаться, но кажется, на слайдах лекции допущена небольшая ошибка. В методе в локальной памятью предлагается записывать тайл из локальной памяти в порядке j в итоговом массиве - то есть тоже столбиками, что может сильно навредить, если наша рабочая группа разнесена на несколько варпов. Я в matrix_transpose.cl положил реализацию с лекционного слайда и написал комментарий, где у меня возник вопрос. Буду очень признателен, если вы мне подскажете, прав ли я, что это опечатка и выбранная мной реализация эффективнее.
В остальном открытий нет, разве что в том, что реализация с bank conflicts не быстрее, чем наивная - я предполагаю, что это может быть связано с умным префетчером, т.к. паттерн доступа к памяти в наивном варианте куда более предсказуемый.

multiplication:
Здесь решение с тайлами лишь немного быстрее наивного - опять же, думаю, дело в префетчере.
А вот самым быстрым оказался метод с WPT с параметрами wpt=2 и ts=16. Кажется, что это связано с количеством потоков в моём execution unit (аналог warp в Apple Silicon) - их 8, а это ровно ts / wp. То есть каждый тайл обрабатывается ровно одним варпом, и каждый поток в варпе обрабатывает ровно по 2 клетки, а так же никто никого не ждет на барьерах.