### PR TITLE
Task04 Дмитрий Артюхов HSE 

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,98 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
-{
-    // TODO
+__kernel void matrix_multiplication_naive(
+    __global float* A, // [M x K] - first is rows cnt, second columns
+    __global float* B, // [K x N]
+    __global float* C, // [M x N]
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+) {
+    size_t gx = get_global_id(0); // in [0, N)
+    size_t gy = get_global_id(1); // in [0, M)
+
+    float sum = 0.0;
+    for (int k = 0; k < K; ++k) {
+        sum += A[gy * K + k] * B[k * N + gx];
+    }
+    C[gy * N + gx] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
-{
-    // TODO
+__kernel void matrix_multiplication_local(
+    __global float* A, // [M x K] - first is rows cnt, second columns
+    __global float* B, // [K x N]
+    __global float* C, // [M x N]
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+) {
+    int gx = get_global_id(0);
+    int gy = get_global_id(1);
+    int lx = get_local_id(0);
+    int ly = get_local_id(1);
+
+    __local float tile_A[TILE_SIZE][TILE_SIZE];
+    __local float tile_B[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.f;
+    for (int k = 0; k * TILE_SIZE < K; k++) {
+        tile_A[lx][ly] = A[gx * K + ly + (k * TILE_SIZE)];
+        tile_B[lx][ly] = B[(lx + k * TILE_SIZE) * N + gy];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int j = 0; j < TILE_SIZE; j++) {
+            sum += tile_A[lx][j] * tile_B[j][ly];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    C[gx * N + gy] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
-{
-    // TODO
+__kernel void matrix_multiplication_local_wpt(
+    __global float* A, // [M x K] - first is rows cnt, second columns
+    __global float* B, // [K x N]
+    __global float* C, // [M x N]
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+) {
+    int gx = get_global_id(0);
+    int gy = get_global_id(1);
+    int lx = get_local_id(0);
+    int ly = get_local_id(1);
+
+    __local float tile_A[TILE_SIZE][TILE_SIZE];
+    __local float tile_B[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD] = { 0.0f };
+
+    for (int k = 0; k * TILE_SIZE < K; k++) {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+
+            tile_A[lx * WORK_PER_THREAD + w][ly] = A[(gx * WORK_PER_THREAD + w) * K + ly + (k * TILE_SIZE)];
+            tile_B[lx * WORK_PER_THREAD + w][ly] = B[((lx * WORK_PER_THREAD + w) + (k * TILE_SIZE)) * N + gy];
+        }
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            for (int j = 0; j < TILE_SIZE; j++) {
+                sum[w] += tile_A[lx * WORK_PER_THREAD + w][j] * tile_B[j][ly];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        C[(gx * WORK_PER_THREAD + w) * N + gy] = sum[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,70 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
-{
-    // TODO
+__kernel void matrix_transpose_naive(
+    __global float* A,
+    __global float* B,
+    unsigned int Y /* M */,
+    unsigned int X /* K */
+) {
+    size_t gx = get_global_id(0);
+    size_t gy = get_global_id(1);
+    float x = A[gy * X + gx];
+    B[gx * Y + gy] = x;
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+#define TILE_SIZE 16
+__kernel void matrix_transpose_local_bad_banks(
+    __global float* A,
+    __global float* B,
+    unsigned int Y /* M */,
+    unsigned int X /* K */
+) {
+    size_t gx = get_global_id(0);
+    size_t gy = get_global_id(1);
+
+    size_t lx = get_local_id(0);
+    size_t ly = get_local_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    // read from global memory to local and transpose right away
+    tile[lx][ly] = A[gy * X + gx];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // write to global memory
+
+    // Point at location (gx - lx, gy - ly) -- top-left corner of a tile will go to (gy - ly, gx - lx)
+    // If we want to have coalesed write, then we must write from tile from top-left to bottom-right to appropriate locations in B
+    // So from top-left corner if we take cell (lx, ly) then it will go to (gy - ly + lx, gx - lx + ly)
+
+    size_t new_gx = gy - ly + lx;
+    size_t new_gy = gx - lx + ly;
+
+    B[new_gy * Y + new_gx] = tile[ly][lx];
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_good_banks(
+    __global float* A,
+    __global float* B,
+    unsigned int Y /* M */,
+    unsigned int X /* K */
+) {
+    size_t gx = get_global_id(0);
+    size_t gy = get_global_id(1);
+
+    size_t lx = get_local_id(0);
+    size_t ly = get_local_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
+
+    // read from global memory to local and transpose right away
+    tile[lx][ly] = A[gy * X + gx];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // write to global memory
+    size_t new_gx = gy - ly + lx;
+    size_t new_gy = gx - lx + ly;
+
+    B[new_gy * Y + new_gx] = tile[ly][lx];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,9 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
+    //throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +60,9 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
+    //throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +70,9 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
+    //throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size / wpt, tile_size, M / wpt, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -122,42 +122,47 @@ void runTest(const KernelConfig &config, const float *as, const float *bs, const
     }
 }
 
-int main(int argc, char **argv)
-{
-    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+int main(int argc, char **argv) {
+    try {
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-    gpu::Context context;
-    context.init(device.device_id_opencl);
-    context.activate();
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
 
-    std::vector<float> as(M*K, 0);
-    std::vector<float> bs(K*N, 0);
-    FastRandom r(M+K+N);
-    for (unsigned int i = 0; i < as.size(); ++i) {
-        as[i] = r.nextf();
+        std::vector<float> as(M*K, 0);
+        std::vector<float> bs(K*N, 0);
+        FastRandom r(M+K+N);
+        for (unsigned int i = 0; i < as.size(); ++i) {
+            as[i] = r.nextf();
+        }
+        for (unsigned int i = 0; i < bs.size(); ++i) {
+            bs[i] = r.nextf();
+        }
+        std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
+
+        const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
+
+        runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
+        runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
+        runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
+
+        runTest(makeLocalConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
+        runTest(makeLocalConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
+        runTest(makeLocalConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
+
+        for (unsigned int tile_size : {4, 8, 16}) {
+            for (unsigned int wpt : {2, 4, 8, 16}) {
+                if (wpt <= tile_size) {
+                    runTest(makeLocalWPTConfig(tile_size, wpt), as.data(), bs.data(), cs_cpu_reference.data());
+                }
+            }
+        }
+
+        return 0;
     }
-    for (unsigned int i = 0; i < bs.size(); ++i) {
-        bs[i] = r.nextf();
+    catch (const std::exception& err) {
+        std::cerr << err.what() << std::endl;
+        throw;
     }
-    std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
-
-    const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
-
-    runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeNaiveConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
-
-    runTest(makeLocalConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeLocalConfig(8), as.data(), bs.data(), cs_cpu_reference.data());
-    runTest(makeLocalConfig(16), as.data(), bs.data(), cs_cpu_reference.data());
-
-    for (unsigned int tile_size : {4, 8, 16})
-        for (unsigned int wpt : {2, 4, 8, 16})
-            if (wpt <= tile_size)
-                runTest(makeLocalWPTConfig(tile_size, wpt), as.data(), bs.data(), cs_cpu_reference.data());
-
-    return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./matrix_transpose
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #2: GPU. Intel(R) UHD Graphics 620. Total memory: 6507 Mb
  Device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Using device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00788333+-0.000634867 s
    GPU: 2128.19 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.00445+-0.000497494 s
    GPU: 3770.16 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.005+-0 s
    GPU: 3355.44 millions/s



$ ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. Intel(R) Corporation. Total memory: 16268 Mb
  Device #2: GPU. Intel(R) UHD Graphics 620. Total memory: 6507 Mb
  Device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Using device #3: GPU. NVIDIA GeForce MX150. Total memory: 2047 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 4.15+-0 s
CPU: 0.481928 GFlops
[naive, ts=4]
    GPU: 0.122333+-0.000745356 s
    GPU: 16.3488 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.0655+-0.0005 s
    GPU: 30.5344 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.0411667+-0.000897527 s
    GPU: 48.583 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.1145+-0.00214087 s
    GPU: 17.4672 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.037+-0.00141421 s
    GPU: 54.0541 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.0546667+-0.00309121 s
    GPU: 36.5854 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.1225+-0.00229129 s
    GPU: 16.3265 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.138667+-0.00221108 s
    GPU: 14.4231 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.032+-0 s
    GPU: 62.5 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.0328333+-0.000687184 s
    GPU: 60.9137 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.0515+-0.0005 s
    GPU: 38.835 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.075+-0.0046188 s
    GPU: 26.6667 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.0411667+-0.00203443 s
    GPU: 48.583 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.013+-0 s
    GPU: 153.846 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.015+-0 s
    GPU: 133.333 GFlops
    Average difference: 0.000196008%
</pre>

</p></details>


<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0168294+-0.000122194 s
    GPU: 996.9 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0152879+-5.87652e-05 s
    GPU: 1097.42 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0152102+-3.25034e-05 s
    GPU: 1103.02 millions/s


$ ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.20045+-0 s
CPU: 0.322557 GFlops
[naive, ts=4]
    GPU: 0.227817+-0.00312343 s
    GPU: 8.77896 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.26327+-0.00630375 s
    GPU: 7.59676 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.273431+-0.00664754 s
    GPU: 7.31446 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.585203+-0.00170874 s
    GPU: 3.41762 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.316625+-0.00211969 s
    GPU: 6.31662 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.289748+-0.00129906 s
    GPU: 6.90255 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.527072+-0.00147261 s
    GPU: 3.79455 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.442363+-0.000480369 s
    GPU: 4.52118 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.313247+-0.000881516 s
    GPU: 6.38474 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.287071+-0.00306148 s
    GPU: 6.96691 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.272379+-0.00222147 s
    GPU: 7.34272 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.238817+-0.00149262 s
    GPU: 8.37461 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.233186+-0.00226889 s
    GPU: 8.57686 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.191495+-0.00121761 s
    GPU: 10.4442 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.189267+-0.00566841 s
    GPU: 10.5671 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>



- Про `matrix_transpose`: для транспозиции матриц на моем ПК вариант со сдвинутыми элементами для устранения банк-конфликтов стабильно хуже отрабатывает, чем вариант без сдвига, причем существенно. Возможно, это из-за большего числа считанных кэш-линий из локальной памяти во время чтения перед записью в глобальную. Тут я добавил по одному флоту в каждую строчку тайла, то есть всего 16 доп. флотов, что 1 доп. кэш-линия на каждую ворк-группу. А всего ворк-групп `M * K / (16 * 16) = 65536`, то есть  довольно много лишних загрузок в кэш.