### PR TITLE
Task04 Igor Bereza SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,90 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float sum = 0;
+    for (int k = 0; k < K; k++) {
+        sum += a[k + j * K] * b[i + k * N];
+    }
+
+    c[i + j * N] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0;
+    for (int tile_k = 0; tile_k * TILE_SIZE < K; tile_k++) {
+        int tile_i = local_i + tile_k * TILE_SIZE;
+        int tile_j = local_j + tile_k * TILE_SIZE;
+
+        tile_a[local_j][local_i] = a[tile_i + j * K];
+        tile_b[local_j][local_i] = b[i + tile_j * N];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            sum += tile_a[local_j][k] * tile_b[k][local_i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    c[i + j * N] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+#define RTS (TILE_SIZE / WORK_PER_THREAD)
+__kernel void matrix_multiplication_local_wpt(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N)
 {
-    // TODO
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    int i = get_group_id(0) * TILE_SIZE + local_i;
+    int j = get_group_id(1) * TILE_SIZE + local_j;
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float acc[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        acc[w] = 0;
+    }
+
+    for (int t = 0; t < K / TILE_SIZE; t++) {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            tile_a[local_j + w * RTS][local_i] = a[(local_i + t * TILE_SIZE) + (j       + w * RTS)                 * K];
+            tile_b[local_j + w * RTS][local_i] = b[i                         + (local_j + t * TILE_SIZE + w * RTS) * N];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            for (int w = 0; w < WORK_PER_THREAD; w++) {
+                acc[w] += tile_a[local_j + w * RTS][k] * tile_b[k][local_i];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        c[(j + w * RTS) * N + i] = acc[w];
+    }
 }
 #endif
+

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,52 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+__kernel void matrix_transpose_naive(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float x = a[i + j * k];
+
+    at[j + i * m] = x;
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+#define TILE_SIZE 16
+__kernel void matrix_transpose_local_bad_banks(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[i + j * k];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int out_i = local_j + get_group_id(0) * TILE_SIZE;
+    int out_j = local_i + get_group_id(1) * TILE_SIZE;
+
+    at[out_j + out_i * m] = tile[local_i][local_j];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[i + j * k];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int out_i = local_j + get_group_id(0) * TILE_SIZE;
+    int out_j = local_i + get_group_id(1) * TILE_SIZE;
+
+    at[out_j + out_i * m] = tile[local_i][local_j];
 }
+

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, N, M);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, N, M);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +139,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -33,9 +33,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(16, 16, ((M + 16 - 1) / 16) * 16, ((K + 16 - 1) / 16) * 16);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -74,12 +73,10 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    // TODO uncomment
-    return 0;
-
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());
     runTest("matrix_transpose_local_good_banks", as.data());
 
     return 0;
 }
+


### PR DESCRIPTION
<details><summary>Локальный вывод (Matrix transpose) </summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) Arc(TM) A770 Graphics. Total memory: 15930 Mb
Using device #0: GPU. Intel(R) Arc(TM) A770 Graphics. Total memory: 15930 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.003+-0 s
    GPU: 5592.41 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0004+-0.000489898 s
    GPU: 41943 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000416667+-0.000493007 s
    GPU: 40265.3 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI (Matrix transpose) </summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0151774+-8.46336e-05 s
    GPU: 1105.41 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0135908+-3.62628e-05 s
    GPU: 1234.45 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0140766+-5.07537e-05 s
    GPU: 1191.85 millions/s
</pre>
</p></details>
Перенос вычислений в локальную память очень сильно увеличивает производительность, а bank-конфликты практически не дают выигрыша (иногда даже замедляют).

<details><summary>Локальный вывод (Matrix multiplication) </summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) Arc(TM) A770 Graphics. Total memory: 15930 Mb
Using device #0: GPU. Intel(R) Arc(TM) A770 Graphics. Total memory: 15930 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.254+-0 s
CPU: 0.614628 GFlops
[naive, ts=4]
    GPU: 0.00283333+-0.000372678 s
    GPU: 705.882 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.00183333+-0.000372678 s
    GPU: 1090.91 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.00183333+-0.000372678 s
    GPU: 1090.91 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.00316667+-0.000372678 s
    GPU: 631.579 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.00566667+-0.000471405 s
    GPU: 352.941 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.0065+-0.0005 s
    GPU: 307.692 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.00183333+-0.000372678 s
    GPU: 1090.91 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.000666667+-0.000471405 s
    GPU: 3000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.00216667+-0.000372678 s
    GPU: 923.077 GFlops
    Average difference: 0.000196008%
</pre>
</p></details>

<details><summary>Вывод Github CI (Matrix multiplication)</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.28507+-0 s
CPU: 0.318215 GFlops
[naive, ts=4]
    GPU: 0.26194+-0.00137303 s
    GPU: 7.63532 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.236098+-0.00175499 s
    GPU: 8.47106 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.264358+-0.00495247 s
    GPU: 7.56548 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.580154+-0.0011502 s
    GPU: 3.44736 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.146195+-0.000270317 s
    GPU: 13.6803 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0894632+-0.00020259 s
    GPU: 22.3556 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.538234+-0.000379371 s
    GPU: 3.71586 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.439925+-0.000760673 s
    GPU: 4.54623 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.13342+-0.000604666 s
    GPU: 14.9902 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.169248+-0.000373921 s
    GPU: 11.817 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.144432+-0.000497573 s
    GPU: 13.8473 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0778132+-7.20079e-05 s
    GPU: 25.7026 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0800972+-0.000134908 s
    GPU: 24.9697 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0789073+-0.000832583 s
    GPU: 25.3462 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0912527+-0.000961993 s
    GPU: 21.9172 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>
Локальная память в этом случае также даёт значительный прирост, как и перераспределение вычислений путём уменьшения числа потоков за счёт увеличения нагрузки для каждого отдельного потока. На моей видеокарте, видимо, оптимальный work_per_thread близок к корню из tile_size, чего на тестовом процессоре не наблюдается. Скорее всего, на процессоре разрыв между временем доступа к локальной памяти и доступа к глобальной памяти намного меньше, чем на видеокарте, поэтому на процессоре выигрыш от последней оптимизации наблюдать сложнее.