### PR TITLE
Task04 Алсу Верещагина ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,109 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
-{
-    // TODO
+__kernel void matrix_multiplication_naive(
+    __global float *a,
+    __global float *b,
+    __global float *c,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    
+    if (i >= N || j >= M) {
+        return;
+    }
+    
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k) {
+        sum += a[j * K + k] * b[k * N + i];
+    }
+    c[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
-{
-    // TODO
+__kernel void matrix_multiplication_local(
+    __global float *a,
+    __global float *b,
+    __global float *c,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    
+    if (i >= N || j >= M) {
+        return;
+    }
+    
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+    
+    float sum = 0.0f;
+    for (int tileK = 0; tileK * TILE_SIZE < K; ++tileK) {
+        tileA[local_j][local_i] = a[j * K + (tileK * TILE_SIZE + local_i)];
+        tileB[local_j][local_i] = b[(tileK * TILE_SIZE + local_j) * K + i];
+        barrier(CLK_LOCAL_MEM_FENCE);
+        
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    c[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
-{
-    // TODO
+__kernel void matrix_multiplication_local_wpt(
+    __global float *a,
+    __global float *b,
+    __global float *c,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1) * WORK_PER_THREAD;
+
+    if (i >= N || j >= M) {
+        return;
+    }
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1) * WORK_PER_THREAD;
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; ++w) {
+        sum[w] = 0.0f;
+    }
+
+    for (int tileK = 0; tileK * TILE_SIZE < K; ++tileK) {
+        for (int w = 0; w < WORK_PER_THREAD; ++w) {
+            tileA[local_j + w][local_i] = a[(j + w) * K + (tileK * TILE_SIZE + local_i)];
+            tileB[local_j + w][local_i] = b[(tileK * TILE_SIZE + local_j + w) * K + i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            for (int w = 0; w < WORK_PER_THREAD; ++w) {
+                sum[w] += tileA[local_j + w][k] * tileB[k][local_i];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; ++w) {
+        c[(j + w) * N + i] = sum[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,73 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
-{
-    // TODO
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_naive(
+    __global float *a,
+    __global float *at,
+    unsigned int m,
+    unsigned int k
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    if (i < k && j < m) {
+        at[i * m + j] = a[j * k + i];
+    }
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_bad_banks(
+    __global float *a,
+    __global float *at,
+    unsigned int m,
+    unsigned int k
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    if (i < k && j < m) {
+        tile[local_j][local_i] = a[j * k + i];
+    } else {
+        tile[local_j][local_i] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int target_j = (i - local_i) + local_j;
+    int target_i = (j - local_j) + local_i;
+    if (target_i < k && target_j < m) {
+        at[target_j * k + target_i] = tile[local_i][local_j];
+    }
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_good_banks(
+    __global float *a,
+    __global float *at,
+    unsigned int m,
+    unsigned int k
+) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    if (i < k && j < m) {
+        tile[local_j][local_i] = a[j * k + i];
+    } else {
+        tile[local_j][local_i] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int target_j = (i - local_i) + local_j;
+    int target_i = (j - local_j) + local_i;
+    if (target_i < k && target_j < m) {
+        at[target_j * k + target_i] = tile[local_i][local_j];
+    }
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,10 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    unsigned int workSizeX = (N + tile_size - 1) / tile_size * tile_size;
+    unsigned int workSizeY = (M + tile_size - 1) / tile_size * tile_size;
+    gpu::WorkSize work_size(tile_size, tile_size, workSizeX, workSizeY);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +61,10 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    unsigned int workSizeX = (N + tile_size - 1) / tile_size * tile_size;
+    unsigned int workSizeY = (M + tile_size - 1) / tile_size * tile_size;
+    gpu::WorkSize work_size(tile_size, tile_size, workSizeX, workSizeY);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +72,10 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    unsigned int workSizeX = (N + tile_size - 1) / tile_size * tile_size;
+    unsigned int workSizeY = (M + tile_size - 1) / tile_size * tile_size;
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, workSizeX, workSizeY / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +145,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -33,9 +33,13 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        unsigned int groupSizeX = 16;
+        unsigned int groupSizeY = 16;
+        unsigned int workSizeX = (M + groupSizeX - 1) / groupSizeX * groupSizeX;
+        unsigned int workSizeY = (K + groupSizeY - 1) / groupSizeY * groupSizeY;
+        gpu::WorkSize work_size(groupSizeX, groupSizeY, workSizeX, workSizeY);
+
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +77,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод (транспонирование)</summary><p>

<pre>
# ./matrix_transpose 1
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 24028 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1080. Total memory: 8106 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1080. Total memory: 8106 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00141753+-4.98888e-07 s
    GPU: 11835.5 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.000580517+-5.91373e-07 s
    GPU: 28900.5 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.00057715+-1.38834e-06 s
    GPU: 29069.1 millions/s
</pre>

</p></details>

Как можно видеть, реализация с локальной памятью значительно выигрывает перед наивной реализацией. При этом исключение банк конфликтов ускоряет вычисления, но не настолько сильно.

<details><summary>Локальный вывод (умножение)</summary><p>

<pre>
# ./matrix_multiplication 1
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 24028 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1080. Total memory: 8106 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1080. Total memory: 8106 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.02699+-0 s
CPU: 0.331841 GFlops
[naive, ts=4]
    GPU: 0.0201328+-5.5484e-05 s
    GPU: 99.3402 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.007262+-2.00167e-05 s
    GPU: 275.406 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.00458533+-4.28667e-05 s
    GPU: 436.173 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.0120673+-1.37437e-06 s
    GPU: 165.737 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.00223933+-1.79505e-06 s
    GPU: 893.123 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.00179817+-2.73354e-06 s
    GPU: 1112.24 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.0165227+-3.39935e-06 s
    GPU: 121.046 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.0191332+-1.57418e-05 s
    GPU: 104.531 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.00206767+-5.84998e-06 s
    GPU: 967.274 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.003405+-4.12311e-06 s
    GPU: 587.372 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.00495983+-1.99618e-05 s
    GPU: 403.239 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.00133233+-1.10554e-06 s
    GPU: 1501.13 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.00107717+-2.26691e-06 s
    GPU: 1856.72 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.000895167+-1.95078e-06 s
    GPU: 2234.22 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.00148733+-1.10554e-06 s
    GPU: 1344.69 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>

Как и ожидалось, самая медленная оказалась наивная реализация. При этом увеличение размера рабочей группы улучшает производительность. Реализация с локальной памятью работает в 2.3 раза быстрее на том же размере рабочей группы. Самой быстрой реализацией оказалась реализация с большим количеством работы на один воркайтем. В 2 раза быстрее версии с просто локальной памятью и в 5 раз быстрее наивной реализации. Увеличение количество работы на один поток улучшает производительность, кроме случая, когда оно становится равным рабочей группе. В этом случае немного проседает.