### PR TITLE
Task04 Степан Остапенко ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -41,30 +41,24 @@ __kernel void matrix_multiplication_local(
     __local float tile_b[TILE_SIZE][TILE_SIZE];
 
     float sum = 0;
-    for (unsigned int t = 0; t < (k + TILE_SIZE - 1) / TILE_SIZE; t++) {
-        if (i < m && (t * TILE_SIZE + local_j) < k) {
-            tile_a[local_i][local_j] = a[k * i + (t * TILE_SIZE + local_j)];
-        } else {
-            tile_a[local_i][local_j] = 0.f;
-        }
+    for (unsigned int t = 0; t * TILE_SIZE < k; t++) {
+        unsigned int tile_i = t * TILE_SIZE + local_i;
+        unsigned int tile_j = t * TILE_SIZE + local_j;
 
-        if ((t * TILE_SIZE + local_i) < k && j < n) {
-            tile_b[local_i][local_j] = b[n * (t * TILE_SIZE + local_i) + j];
-        } else {
-            tile_b[local_i][local_j] = 0.f;
-        }
+        tile_a[local_j][local_i] = a[j * k + tile_i];
+        tile_b[local_j][local_i] = b[tile_j * n + i];
 
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (unsigned int k = 0; k < TILE_SIZE; k++) {
-            sum += tile_a[local_i][k] * tile_b[k][local_j];
+            sum += tile_a[local_j][k] * tile_b[k][local_i];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 
     if (i < m && j < n) {
-        c[n * i + j] = sum;
+        c[n * j + i] = sum;
     }
 }
 
@@ -92,27 +86,19 @@ __kernel void matrix_multiplication_local_wpt(
         res[w] = 0.f;
     }
 
-    for (unsigned int t = 0; t < (k + TILE_SIZE - 1) / TILE_SIZE; t++) {
+    for (unsigned int t = 0; t * TILE_SIZE < k; t++) {
         for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
-            if (i < m && t * TILE_SIZE + local_j + w * TILE_PARTS < k) {
-                tile_a[local_i][local_j + TILE_PARTS * w] = a[i * k + t * TILE_SIZE + local_j + w * TILE_PARTS];
-            } else {
-                tile_a[local_i][local_j + TILE_PARTS * w] = 0.f;
-            }
-            if (t * TILE_SIZE + local_i < k && j + w * TILE_PARTS < n) {
-                tile_b[local_i][local_j + w * TILE_PARTS] = b[n * (t * TILE_SIZE + local_i) + j + w * TILE_PARTS];
-            } else {
-                tile_b[local_i][local_j] = 0.f;
-            }
+            tile_a[local_j + w * TILE_PARTS][local_i] = a[(local_i + t * TILE_SIZE) + (j + w * TILE_PARTS) * k];
+            tile_b[local_j + w * TILE_PARTS][local_i] = b[i + (local_j + t * TILE_SIZE + w * TILE_PARTS) * n];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (unsigned int k = 0; k < TILE_SIZE; k++) {
-            float tile_a_value = tile_a[local_i][k];
+            float tile_b_value = tile_b[k][local_i];
 
             for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
-                res[w] += tile_a_value * tile_b[k][local_j + w * TILE_PARTS];
+                res[w] += tile_a[local_j + w * TILE_PARTS][k] * tile_b_value;
             }
         }
 
@@ -120,7 +106,7 @@ __kernel void matrix_multiplication_local_wpt(
     }
 
     for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
-        c[n * i + j + w * TILE_PARTS] = res[w];
+        c[(j + w * TILE_PARTS) * n + i] = res[w];
     }
 }
 

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,121 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
-{
-    // TODO
+__kernel void matrix_multiplication_naive(
+    __global float *a, __global float *b, __global float *c,
+    unsigned int m, unsigned int k, unsigned int n
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= n || j >= m) {
+        return;
+    }
+
+    c[j * n + i] = 0;
+
+    for (unsigned int t = 0; t < k; t++) {
+        c[j * n + i] += a[j * k + t] * b[t * n + i];
+    }
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
-{
-    // TODO
+
+__kernel void matrix_multiplication_local(
+    __global float *a, __global float *b, __global float *c,
+    unsigned int m, unsigned int k, unsigned int n
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0;
+    for (unsigned int t = 0; t < (k + TILE_SIZE - 1) / TILE_SIZE; t++) {
+        if (i < m && (t * TILE_SIZE + local_j) < k) {
+            tile_a[local_i][local_j] = a[k * i + (t * TILE_SIZE + local_j)];
+        } else {
+            tile_a[local_i][local_j] = 0.f;
+        }
+
+        if ((t * TILE_SIZE + local_i) < k && j < n) {
+            tile_b[local_i][local_j] = b[n * (t * TILE_SIZE + local_i) + j];
+        } else {
+            tile_b[local_i][local_j] = 0.f;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (unsigned int k = 0; k < TILE_SIZE; k++) {
+            sum += tile_a[local_i][k] * tile_b[k][local_j];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (i < m && j < n) {
+        c[n * i + j] = sum;
+    }
 }
+
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
-{
-    // TODO
+
+#define TILE_PARTS TILE_SIZE / WORK_PER_THREAD
+
+__kernel void matrix_multiplication_local_wpt(
+    __global float *a, __global float *b, __global float *c,
+    unsigned int m, unsigned int k, unsigned int n
+) {
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    unsigned int i = TILE_SIZE * get_group_id(0) + local_i;
+    unsigned int j = TILE_SIZE * get_group_id(1) + local_j;
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float res[WORK_PER_THREAD];
+    for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
+        res[w] = 0.f;
+    }
+
+    for (unsigned int t = 0; t < (k + TILE_SIZE - 1) / TILE_SIZE; t++) {
+        for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
+            if (i < m && t * TILE_SIZE + local_j + w * TILE_PARTS < k) {
+                tile_a[local_i][local_j + TILE_PARTS * w] = a[i * k + t * TILE_SIZE + local_j + w * TILE_PARTS];
+            } else {
+                tile_a[local_i][local_j + TILE_PARTS * w] = 0.f;
+            }
+            if (t * TILE_SIZE + local_i < k && j + w * TILE_PARTS < n) {
+                tile_b[local_i][local_j + w * TILE_PARTS] = b[n * (t * TILE_SIZE + local_i) + j + w * TILE_PARTS];
+            } else {
+                tile_b[local_i][local_j] = 0.f;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (unsigned int k = 0; k < TILE_SIZE; k++) {
+            float tile_a_value = tile_a[local_i][k];
+
+            for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
+                res[w] += tile_a_value * tile_b[k][local_j + w * TILE_PARTS];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (unsigned int w = 0; w < WORK_PER_THREAD; w++) {
+        c[n * i + j + w * TILE_PARTS] = res[w];
+    }
 }
+
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -35,11 +35,14 @@ __kernel void matrix_transpose_local_bad_banks(
 
     __local float tile[TILE_SIZE][TILE_SIZE];
 
-    tile[local_i][local_j] = as[i * k + j];
+    tile[local_j][local_i] = as[j * k + i];
+
+    unsigned int res_i = get_group_id(0) * TILE_SIZE + local_j;
+    unsigned int res_j = get_group_id(1) * TILE_SIZE + local_i;
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    as_t[j * m + i] = tile[local_i][local_j];
+    as_t[res_i * m + res_j] = tile[local_i][local_j];
 }
 
 __kernel void matrix_transpose_local_good_banks(
@@ -55,9 +58,12 @@ __kernel void matrix_transpose_local_good_banks(
 
     __local float tile[TILE_SIZE][TILE_SIZE + 1];
 
-    tile[local_i][local_j] = as[i * k + j];
+    tile[local_j][local_i] = as[j * k + i];
+
+    unsigned int res_i = get_group_id(0) * TILE_SIZE + local_j;
+    unsigned int res_j = get_group_id(1) * TILE_SIZE + local_i;
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    as_t[j * m + i] = tile[local_i][local_j];
+    as_t[res_i * m + res_j] = tile[local_i][local_j];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,59 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
-{
-    // TODO
+__kernel void matrix_transpose_naive(
+    __global const float *as,
+    __global float *as_t,
+    unsigned int m, unsigned int k
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= k || j >= m) {
+        return;
+    }
+
+    as_t[i * m + j] = as[j * k + i];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_local_bad_banks(
+    __global const float *as,
+    __global float *as_t,
+    unsigned int m, unsigned int k
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    tile[local_i][local_j] = as[i * k + j];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[j * m + i] = tile[local_i][local_j];
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_good_banks(
+    __global const float *as,
+    __global float *as_t,
+    unsigned int m, unsigned int k
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
+
+    tile[local_i][local_j] = as[i * k + j];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[j * m + i] = tile[local_i][local_j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -116,7 +113,7 @@ void runTest(const KernelConfig &config, const float *as, const float *bs, const
     }
 
     double diff_avg = diff_sum / (M * N);
-    std::cout <<"    Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+    std::cout << "    Average difference: " << diff_avg * 100.0 << "%" << std::endl;
     if (diff_avg > 0.01) {
         throw std::runtime_error("Too big difference!");
     }
@@ -142,9 +139,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -14,6 +14,8 @@ const int benchmarkingIters = 100;
 const unsigned int M = 4096;
 const unsigned int K = 4096;
 
+const int GROUP_SIZE = 16;
+
 void runTest(const std::string &kernel_name, const float *as)
 {
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
@@ -34,8 +36,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
         // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(GROUP_SIZE, GROUP_SIZE, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +75,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
## Транспонирование

<details><summary>Локальный вывод</summary><p>

<pre>
$ build/matrix_transpose
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0307102+-0.0009508 s
    GPU: 546.308 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0247888+-0.00109199 s
    GPU: 676.808 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0258621+-0.000902169 s
    GPU: 648.719 millions/s

</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0152805+-8.21394e-05 s
    GPU: 1097.95 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0128364+-9.7106e-05 s
    GPU: 1307.01 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0133738+-4.7326e-05 s
    GPU: 1254.48 millions/s

</pre>

</p></details>

#### Анализ

Версия с локальной памятью работает быстрее. Однако, версия без банк-конфликтов работает медленнее, чем версия с ними. Возможно, так происходит из-за того, что все запуски, на самом деле, производятся не на видеокарте.

## Перемножение

<details><summary>Локальный вывод</summary><p>

<pre>
$ build/matrix_multiplication
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 19.0119+-0 s
CPU: 0.105197 GFlops
[naive, ts=4]
    GPU: 1.14063+-0.0155268 s
    GPU: 1.75342 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 1.165+-0.0183534 s
    GPU: 1.71674 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 1.12452+-0.0434398 s
    GPU: 1.77854 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 1.69639+-0.0283885 s
    GPU: 1.17898 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.437834+-0.00900476 s
    GPU: 4.56794 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.186278+-0.00166693 s
    GPU: 10.7366 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 1.29766+-0.0237967 s
    GPU: 1.54123 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 1.02239+-0.00928993 s
    GPU: 1.95621 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.452566+-0.0557543 s
    GPU: 4.41924 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.424469+-0.00632976 s
    GPU: 4.71177 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.400385+-0.00434294 s
    GPU: 4.9952 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.154511+-0.0024339 s
    GPU: 12.9441 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.154981+-0.00198396 s
    GPU: 12.9048 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.16462+-0.00344434 s
    GPU: 12.1492 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.183763+-0.00166646 s
    GPU: 10.8836 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.12237+-0 s
CPU: 0.326671 GFlops
[naive, ts=4]
    GPU: 0.304688+-0.0029306 s
    GPU: 6.56409 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.300988+-0.00377763 s
    GPU: 6.64477 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.310286+-0.00316194 s
    GPU: 6.44566 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.582583+-0.00245077 s
    GPU: 3.43299 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.146946+-0.000157898 s
    GPU: 13.6105 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0914927+-0.000363656 s
    GPU: 21.8597 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.535213+-0.000444537 s
    GPU: 3.73683 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.469205+-0.00176463 s
    GPU: 4.26253 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.135873+-0.000678173 s
    GPU: 14.7196 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.174738+-0.000811768 s
    GPU: 11.4457 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.130474+-0.000235371 s
    GPU: 15.3287 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0760593+-0.000220241 s
    GPU: 26.2953 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0763983+-0.000268824 s
    GPU: 26.1786 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0803245+-0.000651183 s
    GPU: 24.899 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0932422+-0.000446313 s
    GPU: 21.4495 GFlops
    Average difference: 0.000149043%

</pre>

</p></details>

#### Анализ

* Наивная версия работает примерно одинаково вне зависимости от размера тайла.
* Версия с локальной памятью работает значительно быстрее; лучше всего при `TILE_SIZE = 16`.
* Третья версия (с уменьшением количества чтений) работает быстрее всех; лучшая комбинация: `TILE_SIZE = 16` и `WORK_PER_THREAD = 2`.