### PR TITLE
Task04 Алексей Казаков ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,131 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(
+    __global const float* A,
+    __global const float* B,
+    __global float* C,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+)
 {
-    // TODO
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (i >= N || j >= M) {
+        return;
+    }
+
+    float sum = 0.0f;
+    for (int t = 0; t < K; ++t) {
+        sum += A[j * K + t] * B[t * N + i];
+    }
+
+    C[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(
+    __global const float* A,
+    __global const float* B,
+    __global float* C,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+)
 {
-    // TODO
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+
+    for (int tile_k = 0; tile_k < K; tile_k += TILE_SIZE) {
+        if (tile_k + local_i < K && j < M) {
+            tileA[local_j][local_i] = A[j * K + (tile_k + local_i)];
+        } else {
+            tileA[local_j][local_i] = 0;
+        }
+        if (i < N && tile_k + local_j < K) {
+            tileB[local_j][local_i] = B[(tile_k + local_j) * N + i];
+        } else {
+            tileB[local_j][local_i] = 0;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    C[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(
+    __global const float* A,
+    __global const float* B,
+    __global float* C,
+    unsigned int M,
+    unsigned int K,
+    unsigned int N
+)
 {
-    // TODO
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD];
+    for (int h = 0; h < WORK_PER_THREAD; ++h) {
+        sum[h] = 0.0f;
+    }
+
+    for (int tile_k = 0; tile_k < K; tile_k += TILE_SIZE) {
+        const unsigned int local_i_base = local_i * WORK_PER_THREAD;
+        for (int h = 0; h < WORK_PER_THREAD; ++h) {
+            {
+                const unsigned int ii = tile_k + local_i_base + h;
+                if (ii < K && j < M) {
+                    tileA[local_j][local_i_base + h] = A[j * K + ii];
+                } else {
+                    tileA[local_j][local_i_base + h] = 0;
+                }
+            }
+
+            {
+                const unsigned int ii = i * WORK_PER_THREAD + h;
+                const unsigned int jj = tile_k + local_j;
+                if (ii < N && jj < K) {
+                    tileB[local_j][local_i_base + h] = B[jj * N + ii];
+                } else {
+                    tileB[local_j][local_i_base + h] = 0;
+                }
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            const float a = tileA[local_j][k];
+            for (int h = 0; h < WORK_PER_THREAD; ++h) {
+                sum[h] += a * tileB[k][local_i_base + h];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int h = 0; h < WORK_PER_THREAD; ++h) {
+        C[j * N + i * WORK_PER_THREAD + h] = sum[h];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,79 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+__kernel void matrix_transpose_naive(
+    __global const float* in,
+    __global float* out,
+    unsigned int M,
+    unsigned int K
+)
 {
-    // TODO
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (i >= K || j >= M) {
+        return;
+    }
+
+    out[i * M + j] = in[j * K + i];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+#define TILE_SIZE 16
+__kernel void matrix_transpose_local_bad_banks(
+    __global const float* in,
+    __global float* out,
+    unsigned int M,
+    unsigned int K
+)
 {
-    // TODO
-}
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+    if (i >= K || j >= M) {
+        return;
+    }
+
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+
+    __local float local_buffer[TILE_SIZE][TILE_SIZE];
+
+    local_buffer[local_j][local_i] = in[j * K + i];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const unsigned int target_i = i - local_i + local_j;
+    const unsigned int target_j = j - local_j + local_i;
+
+    out[target_i * M + target_j] = local_buffer[local_i][local_j];
 }
+#undef TILE_SIZE
+
+#define TILE_SIZE 16
+__kernel void matrix_transpose_local_good_banks(
+    __global const float* in,
+    __global float* out,
+    unsigned int M,
+    unsigned int K
+)
+{
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (i >= K || j >= M) {
+        return;
+    }
+
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+
+    __local float local_buffer[TILE_SIZE][TILE_SIZE + 1];
+
+    local_buffer[local_j][local_i] = in[j * K + i];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const unsigned int target_i = i - local_i + local_j;
+    const unsigned int target_j = j - local_j + local_i;
+
+    out[target_i * M + target_j] = local_buffer[local_i][local_j];
+}
+#undef TILE_SIZE

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,13 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(
+        tile_size,
+        tile_size,
+        tile_size * ((N + tile_size - 1) / tile_size),
+        tile_size * ((M + tile_size - 1) / tile_size)
+    );
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +64,13 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(
+        tile_size,
+        tile_size,
+        tile_size * ((N + tile_size - 1) / tile_size),
+        tile_size * ((M + tile_size - 1) / tile_size)
+    );
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +78,13 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(
+        tile_size / wpt,
+        tile_size,
+        (tile_size * ((N + tile_size - 1) / tile_size)) / wpt,
+        tile_size * ((M + tile_size - 1) / tile_size)
+    );
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +154,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -80,10 +80,10 @@ KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
     std::string kernel_name = "matrix_multiplication_local_wpt";
     gpu::WorkSize work_size(
-        tile_size / wpt,
         tile_size,
-        (tile_size * ((N + tile_size - 1) / tile_size)) / wpt,
-        tile_size * ((M + tile_size - 1) / tile_size)
+        tile_size / wpt,
+        tile_size * ((N + tile_size - 1) / tile_size),
+        (tile_size * ((M + tile_size - 1) / tile_size)) / wpt
     );
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -33,9 +33,14 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        const unsigned int tile_size = 16;
+        gpu::WorkSize work_size(
+            tile_size,
+            tile_size,
+            tile_size * ((K + tile_size - 1) / tile_size),
+            tile_size * ((M + tile_size - 1) / tile_size)
+        );
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +78,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION

<details><summary>Локальный вывод</summary><p>

<pre>
matrix_transpose:
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16084 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6433 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.001+-0 s
    GPU: 16777.2 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0006+-0.000489898 s
    GPU: 27962 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000583333+-0.000493007 s
    GPU: 28760.9 millions/s

matrix_multiplication:
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16084 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6433 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 2.384+-0 s
CPU: 0.838926 GFlops
[naive, ts=4]
    GPU: 0.0156667+-0.000471405 s
    GPU: 127.66 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.00483333+-0.000372678 s
    GPU: 413.793 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.003+-4.1159e-11 s
    GPU: 666.667 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.014+-0 s
    GPU: 142.857 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.003+-4.1159e-11 s
    GPU: 666.667 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.017+-0 s
    GPU: 117.647 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.021+-0 s
    GPU: 95.2381 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.00316667+-0.000372678 s
    GPU: 631.579 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.005+-0 s
    GPU: 400 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.0085+-0.0005 s
    GPU: 235.294 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.00366667+-0.000471405 s
    GPU: 545.455 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.00683333+-0.000372678 s
    GPU: 292.683 GFlops
    Average difference: 0.000196008%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
matrix_transpose:
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0151415+-6.25072e-05 s
    GPU: 1108.03 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0213192+-0.00021247 s
    GPU: 786.952 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0216639+-0.000164394 s
    GPU: 774.43 millions/s

matrix_multiplication:
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.46676+-0 s
CPU: 0.309274 GFlops
[naive, ts=4]
    GPU: 0.259004+-0.0014526 s
    GPU: 7.72189 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.229642+-0.00324765 s
    GPU: 8.70921 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.265519+-0.00592243 s
    GPU: 7.53241 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.614496+-0.00217228 s
    GPU: 3.2547 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.12495+-0.00043705 s
    GPU: 16.0064 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0775818+-0.000196241 s
    GPU: 25.7792 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.580933+-0.000934428 s
    GPU: 3.44274 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.488682+-0.00166994 s
    GPU: 4.09264 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.352965+-0.00183662 s
    GPU: 5.66628 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.298732+-0.000151574 s
    GPU: 6.69496 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.266767+-0.000336121 s
    GPU: 7.49717 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.226111+-0.000718475 s
    GPU: 8.8452 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.193201+-0.00128767 s
    GPU: 10.3519 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.369742+-0.00118524 s
    GPU: 5.40918 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.324548+-0.00191246 s
    GPU: 6.16241 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>

4.1.2: как и ожидалось, на GPU версия алгоритма транспонирования матриц с выносом части вычислений в локальную память работает значительно быстрее наивной реализации. Улучшение же паттерна доступа к банкам памяти дает лишь небольшое ускорение. Возможно, на современном железе/драйверах уже предусмотрены механизмы борьбы с плохими паттернами обращения к локальной памяти

4.2.3: на моем железе оба ненаивных подхода к умножению матриц показали примерно одинаковые результаты (лучшие при TILE_SIZE=16 и WORK_PER_THREAD=4). На CI же, неожиданно, версия WPT оказалась в ~2.5 раза медленнее простой версии с локальной памятью. Думаю, это может быть связано с тем, что вычисления запускались на CPU. Или я реализовал WPT не самым эффективным образом.