### PR TITLE
Task04 Антон Аксенов ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,5 +1,7 @@
 #ifdef __CLION_IDE__
-    #include <libgpu/opencl/cl/clion_defines.cl>
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 
@@ -7,21 +9,108 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
-{
-    // TODO
+__kernel void matrix_multiplication_naive(
+        __global float *as,
+        __global float *bs,
+        __global float *cs,
+        const unsigned int M,
+        const unsigned int K,
+        const unsigned int N
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= N || j >= M)
+        return;
+
+    float sum = 0.0f;
+    for (unsigned int k = 0; k < K; k++)
+        sum += as[j * K + k] * bs[k * N + i];
+    cs[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
-{
-    // TODO
+__kernel void matrix_multiplication_local(
+        __global float *as,
+        __global float *bs,
+        __global float *cs,
+        const unsigned int M,
+        const unsigned int K,
+        const unsigned int N
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    float sum = 0.0f;
+    for (int tile_start = 0; tile_start < K; tile_start += TILE_SIZE) {
+        if (i < N && j < M && tile_start + local_i < K)
+            tile_a[local_j][local_i] = as[(tile_start + local_i) + j * K];
+        else
+            tile_a[local_j][local_i] = 0.0f;
+
+        if (i < N && j < M && tile_start + local_j < K)
+            tile_b[local_j][local_i] = bs[i + (tile_start + local_j) * K];
+        else
+            tile_b[local_j][local_i] = 0.0f;
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int l = 0; l < TILE_SIZE; ++l)
+            sum += tile_a[local_j][l] * tile_b[l][local_i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (i < N && j < M)
+        cs[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
-{
-    // TODO
+__kernel void matrix_multiplication_local_wpt(
+        __global float *as,
+        __global float *bs,
+        __global float *cs,
+        const unsigned int M,
+        const unsigned int K,
+        const unsigned int N
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    float sum = 0.0f;
+    for (int tile_start = 0; tile_start < K; tile_start += TILE_SIZE) {
+        if (i < N && j < M && tile_start + local_i < K)
+            tile_a[local_j][local_i] = as[(tile_start + local_i) + j * K];
+        else
+            tile_a[local_j][local_i] = 0.0f;
+
+        if (i < N && j < M && tile_start + local_j < K)
+            tile_b[local_j][local_i] = bs[i + (tile_start + local_j) * N];
+        else
+            tile_b[local_j][local_i] = 0.0f;
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int l = 0; l < TILE_SIZE; ++l)
+            sum += tile_a[local_j][l] * tile_b[l][local_i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (i < N && j < M)
+        cs[j * N + i] = sum;
 }
 #endif

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -94,7 +94,7 @@ __kernel void matrix_multiplication_local_wpt(
     for (int tile_start = 0; tile_start < (K + TILE_SIZE - 1) / TILE_SIZE; tile_start++) {
         for (int w = 0; w < WORK_PER_THREAD; w++) {
             tile_a[local_j * WORK_PER_THREAD + w][local_i] = as[(tile_start * TILE_SIZE + local_i) + (j * WORK_PER_THREAD + w) * K];
-            tile_b[local_j * WORK_PER_THREAD + w][local_i] = bs[(local_i) + (tile_start * TILE_SIZE + local_j * WORK_PER_THREAD + w) * N];
+            tile_b[local_j * WORK_PER_THREAD + w][local_i] = bs[(i) + (tile_start * TILE_SIZE + local_j * WORK_PER_THREAD + w) * N];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -90,27 +90,22 @@ __kernel void matrix_multiplication_local_wpt(
     unsigned int local_i = get_local_id(0);
     unsigned int local_j = get_local_id(1);
 
-    float sum = 0.0f;
-    for (int tile_start = 0; tile_start < K; tile_start += TILE_SIZE) {
-        if (i < N && j < M && tile_start + local_i < K)
-            tile_a[local_j][local_i] = as[(tile_start + local_i) + j * K];
-        else
-            tile_a[local_j][local_i] = 0.0f;
-
-        if (i < N && j < M && tile_start + local_j < K)
-            tile_b[local_j][local_i] = bs[i + (tile_start + local_j) * N];
-        else
-            tile_b[local_j][local_i] = 0.0f;
+    float sum[WORK_PER_THREAD] = { 0.0f };
+    for (int tile_start = 0; tile_start < (K + TILE_SIZE - 1) / TILE_SIZE; tile_start++) {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            tile_a[local_j * WORK_PER_THREAD + w][local_i] = as[(tile_start * TILE_SIZE + local_i) + (j * WORK_PER_THREAD + w) * K];
+            tile_b[local_j * WORK_PER_THREAD + w][local_i] = bs[(local_i) + (tile_start * TILE_SIZE + local_j * WORK_PER_THREAD + w) * N];
+        }
 
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (int l = 0; l < TILE_SIZE; ++l)
-            sum += tile_a[local_j][l] * tile_b[l][local_i];
+            for (int w = 0; w < WORK_PER_THREAD; w++)
+                sum[w] += tile_a[local_j * WORK_PER_THREAD + w][l] * tile_b[l][local_i];
 
         barrier(CLK_LOCAL_MEM_FENCE);
     }
-
-    if (i < N && j < M)
-        cs[j * N + i] = sum;
+    for (int w = 0; w < WORK_PER_THREAD; w++)
+        cs[i + (j * WORK_PER_THREAD + w) * N] = sum[w];
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,21 +1,79 @@
 #ifdef __CLION_IDE__
-    #include <libgpu/opencl/cl/clion_defines.cl>
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 
 #line 6
 
-__kernel void matrix_transpose_naive()
-{
-    // TODO
+__kernel void matrix_transpose_naive(
+        __global float *as,
+        __global float *as_t,
+        const unsigned int M,
+        const unsigned int K
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= M || j >= K)
+        return;
+
+    as_t[j * M + i] = as[i * K + j];
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+#define TILE_SIZE 16
+__kernel void matrix_transpose_local_bad_banks(
+        __global float *as,
+        __global float *as_t,
+        const unsigned int M,
+        const unsigned int K
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    unsigned int group_i = get_group_id(0);
+    unsigned int group_j = get_group_id(1);
+
+    unsigned int i_new = group_i * TILE_SIZE + local_j;
+    unsigned int j_new = group_j * TILE_SIZE + local_i;
+
+    tile[local_j][local_i] = as[j * M + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[i_new * K + j_new] = tile[local_i][local_j];
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+#define TILE_SIZE 16
+__kernel void matrix_transpose_local_good_banks(
+        __global float *as,
+        __global float *as_t,
+        const unsigned int M,
+        const unsigned int K
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    unsigned int local_i = get_local_id(0);
+    unsigned int local_j = get_local_id(1);
+
+    __local float tile[TILE_SIZE * (TILE_SIZE + 1)];
+
+    unsigned int group_i = get_group_id(0);
+    unsigned int group_j = get_group_id(1);
+
+    unsigned int i_new = group_i * TILE_SIZE + local_j;
+    unsigned int j_new = group_j * TILE_SIZE + local_i;
+
+    tile[local_j * (TILE_SIZE + 1) + local_i] = as[j * M + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[i_new * K + j_new] = tile[local_i * (TILE_SIZE + 1) + local_j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -10,8 +10,8 @@
 #include <iostream>
 #include <stdexcept>
 
-const int benchmarkingIters = 10;
-const int benchmarkingItersCPU = 1;
+const int benchmarkingIters = 20;
+const int benchmarkingItersCPU = 5;
 const unsigned int M = 1024;
 const unsigned int K = 1024;
 const unsigned int N = 1024;
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +139,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -69,7 +69,7 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(tile_size, tile_size, M, N);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <stdexcept>
 
-const int benchmarkingIters = 100;
+const int benchmarkingIters = 1000;
 const unsigned int M = 4096;
 const unsigned int K = 4096;
 
@@ -33,9 +33,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(16, 16, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +72,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1080. Total memory: 8191 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1080. Total memory: 8191 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.000921667+-0.000268695 s
    GPU: 18203.1 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.000705+-0.000456043 s
    GPU: 23797.5 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000715+-0.000451414 s
    GPU: 23464.6 millions/s


OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1080. Total memory: 8191 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1080. Total memory: 8191 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.636+-0 s
CPU: 0.550055 GFlops
[naive, ts=4]
    GPU: 0.0226667+-0.000471405 s
    GPU: 88.2353 GFlops
    Average difference: 0.000196008%
[naive, ts=8]
    GPU: 0.008+-0 s
    GPU: 250 GFlops
    Average difference: 0.000196008%
[naive, ts=16]
    GPU: 0.005+-0 s
    GPU: 400 GFlops
    Average difference: 0.000196008%
[local, ts=4]
    GPU: 0.012+-0 s
    GPU: 166.667 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.00266667+-0.000471405 s
    GPU: 750 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.0116667+-0.000471405 s
    GPU: 171.429 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.0113333+-0.000471405 s
    GPU: 176.471 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.00233333+-0.000471405 s
    GPU: 857.143 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%

</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 77[6](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:7:7)3 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC [7](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:7:8)763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0176714+-0.00122344 s
    GPU: 949.4 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0127[8](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:7:9)77+-3.57115e-05 s
    GPU: 1311.98 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.013112+-3.5608e-05 s
    GPU: 127[9](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:7:10).53 millions/s

Run ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 77[6](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:7)3 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC [7](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:8)763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.40936+-0.002[8](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:9)3088 s
CPU: 0.312043 GFlops
[naive, ts=4]
    GPU: 0.24912+-0.00108464 s
    GPU: 8.02827 GFlops
    Average difference: 0.00014[9](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:10)043%
[naive, ts=8]
    GPU: 0.251025+-0.00322939 s
    GPU: 7.96734 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.267187+-0.00629728 s
    GPU: 7.48538 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.639459+-0.0011561 s
    GPU: 3.12764 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.12[10](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:11)01+-0.000136987 s
    GPU: 16.5288 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0769096+-9.62587e-05 s
    GPU: 26.0046 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.681992+-0.00[11](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:12)7803 s
    GPU: 2.93259 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.669207+-0.001[12](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:13)486 s
    GPU: 2.98861 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.122856+-0.000155818 s
    GPU: 16.2793 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.122274+-0.000330275 s
    GPU: 16.3567 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.122[13](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:14)1+-0.000216977 s
    GPU: 16.3759 GFlops
    Average difference: 0.000[14](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:15)9043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0791833+-0.000149422 s
    GPU: 25.2578 GFlops
    Average difference: 0.000149043%
[local wpt, ts=[16](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:17), wpt=4]
    GPU: 0.0793999+-0.000166837 s
    GPU: 25.[18](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:19)89 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.079652+-0.000242776 s
    GPU: 25.1092 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0794028+-0.000[20](https://github.com/Clu0D/GPGPUTasks2024/actions/runs/11204975822/job/31143987059#step:8:21)3693 s
    GPU: 25.188 GFlops
    Average difference: 0.000149043%
</pre>

</p></details>

Транспонирование
Получено ускорение приблизительно 30% по сравнению с наивным вариантом. Ускорения при реализации без банк конфликтов нет, даже наоборот небольшое замедление. Возможно в железе уже есть какая-то оптимизация на этот счёт, а увеличение размеров локальной памяти только чуть ухудшило ситуацию.

Умножение
Ускорение более чем в 2 раза при умножении по локальным матрицам.