### PR TITLE
Task04 Виноградов Александр HSE

### DIFF
--- a/PERFOMANCE.md
+++ b/PERFOMANCE.md
@@ -1,0 +1,86 @@
+OpenCL devices:
+  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz. Intel(R) Corporation. Total memory: 32573 Mb
+  Device #1: GPU. Intel(R) UHD Graphics 750. Total memory: 13029 Mb
+  Device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
+Using device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
+Data generated for M=1024, K=1024, N=1024
+CPU: 2.515+-0 s
+CPU: 0.795229 GFlops
+[naive, ts=4]
+    GPU: 0.00766667+-0.000471405 s
+    GPU: 260.87 GFlops
+    Average difference: 0.0138686%
+[naive, ts=8]
+    GPU: 0.00266667+-0.000471405 s
+    GPU: 750 GFlops
+    Average difference: 0.0138686%
+[naive, ts=16]
+    GPU: 0.0025+-0.0005 s
+    GPU: 800 GFlops
+    Average difference: 0.0138686%
+[local, ts=4]
+    GPU: 0.00633333+-0.000471405 s
+    GPU: 315.789 GFlops
+    Average difference: 0.000196008%
+[local, ts=8]
+    GPU: 0.002+-0 s
+    GPU: 1000 GFlops
+    Average difference: 0.000196008%
+[local, ts=16]
+    GPU: 0.00116667+-0.000372678 s
+    GPU: 1714.29 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=4, wpt=2]
+    GPU: 0.00716667+-0.000372678 s
+    GPU: 279.07 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=4, wpt=4]
+    GPU: 0.0106667+-0.000471405 s
+    GPU: 187.5 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=8, wpt=2]
+    GPU: 0.00133333+-0.000471405 s
+    GPU: 1500 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=8, wpt=4]
+    GPU: 0.002+-0 s
+    GPU: 1000 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=8, wpt=8]
+    GPU: 0.003+-4.1159e-11 s
+    GPU: 666.667 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=16, wpt=2]
+    GPU: 0.001+-0 s
+    GPU: 2000 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=16, wpt=4]
+    GPU: 0.000833333+-0.000372678 s
+    GPU: 2400 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=16, wpt=8]
+    GPU: 0.000666667+-0.000471405 s
+    GPU: 3000 GFlops
+    Average difference: 0.000196008%
+[local wpt, ts=16, wpt=16]
+    GPU: 0.001+-0 s
+    GPU: 2000 GFlops
+    Average difference: 0.000196008%
+
+
+
+OpenCL devices:
+  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz. Intel(R) Corporation. Total memory: 32573 Mb
+  Device #1: GPU. Intel(R) UHD Graphics 750. Total memory: 13029 Mb
+  Device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
+Using device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
+Data generated for M=4096, K=4096
+[matrix_transpose_naive]
+    GPU: 0.00045+-0.000497494 s
+    GPU: 37282.7 millions/s
+[matrix_transpose_local_bad_banks]
+    GPU: 0.00035+-0.00047697 s
+    GPU: 47934.9 millions/s
+[matrix_transpose_local_good_banks]
+    GPU: 0.00035+-0.00047697 s
+    GPU: 47934.9 millions/s

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,105 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(__global const float* a,
+                                          __global const float* b,
+                                          __global float* c,
+                                          unsigned int M,
+                                          unsigned int K,
+                                          unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    if (i >= N || j >= M) {
+        return;
+    }
+
+    int sum = 0;
+    for (int k = 0; k < K; ++k) {
+        sum += a[j * K + k] * b[k * N + i];
+    }
+
+    c[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(__global const float* a,
+                                          __global const float* b,
+                                          __global float* c,
+                                          unsigned int M,
+                                          unsigned int K,
+                                          unsigned int N)
 {
-    // TODO
+    __local float local_a[TILE_SIZE][TILE_SIZE];
+    __local float local_b[TILE_SIZE][TILE_SIZE];
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    float sum = 0.0;
+    for (int k = 0; k * TILE_SIZE < K; ++k) {
+        local_a[local_j][local_i] = a[j * K + k * TILE_SIZE + local_i];
+        local_b[local_j][local_i] = b[(k * TILE_SIZE + local_j) * N + i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k1 = 0; k1 < TILE_SIZE; ++k1) {
+            sum += local_a[local_j][k1] * local_b[k1][local_i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    c[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(__global const float* a,
+                                              __global const float* b,
+                                              __global float* c,
+                                              unsigned int M,
+                                              unsigned int K,
+                                              unsigned int N)
 {
-    // TODO
+    __local float local_a[TILE_SIZE][TILE_SIZE];
+    __local float local_b[TILE_SIZE][TILE_SIZE];
+
+    int i = get_global_id(0);
+    int j = get_global_id(1) * WORK_PER_THREAD;
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1) * WORK_PER_THREAD ;
+
+    float sum[WORK_PER_THREAD];
+    for (int wpt = 0; wpt < WORK_PER_THREAD; ++wpt) {
+        sum[wpt] = 0;
+    }
+
+    for (int k = 0; k * TILE_SIZE < K; ++k) {
+        for (int wpt = 0; wpt < WORK_PER_THREAD; ++wpt) {
+            local_a[local_j + wpt][local_i] = a[(j + wpt) * K + k * TILE_SIZE + local_i];
+            local_b[local_j + wpt][local_i] = b[(k * TILE_SIZE + local_j + wpt) * N + i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k1 = 0; k1 < TILE_SIZE; ++k1) {
+            float loc_b = local_b[k1][local_i];
+            for (int wpt = 0; wpt < WORK_PER_THREAD; ++wpt) {
+                sum[wpt] += local_a[local_j + wpt][k1] * loc_b;
+            }
+
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int wpt = 0; wpt < WORK_PER_THREAD; ++wpt) {
+        c[(wpt + j) * N + i] = sum[wpt];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,62 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+__kernel void matrix_transpose_naive(__global   const float* a,
+                                     __global   float* at,
+                                     /* rows */ unsigned int m,
+                                     /* cols */ unsigned int k)
 {
-    // TODO
+    int col = get_global_id(0);
+    int row = get_global_id(1);
+    if (col >= k || row >= m) {
+        return;
+    }
+
+    float x = a[row * k + col];
+    at[col * m + row] = x;
 }
 
-__kernel void matrix_transpose_local_bad_banks()
-{
-    // TODO
+#define TILE_SIZE 16
+__kernel void matrix_transpose_local_bad_banks(__global   const float* a,
+                                               __global   float* at,
+                                               /* rows */ unsigned int m,
+                                               /* cols */ unsigned int k) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    if (i >= k || j >= m) {
+        return;
+    }
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    __local float buf[TILE_SIZE][TILE_SIZE];
+
+    buf[local_i][local_j] = a[i * k + j];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[j * m + i] = buf[local_i][local_j];
 }
 
-__kernel void matrix_transpose_local_good_banks()
-{
-    // TODO
+__kernel void matrix_transpose_local_good_banks(__global   const float* a,
+                                                __global   float* at,
+                                                /* rows */ unsigned int m,
+                                                /* cols */ unsigned int k) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    if (i >= k || j >= m) {
+        return;
+    }
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    __local float buf[TILE_SIZE + 1][TILE_SIZE];
+
+    buf[local_i][local_j] = a[i * k + j];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[j * m + i] = buf[local_i][local_j];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -36,11 +36,14 @@ __kernel void matrix_transpose_local_bad_banks(__global   const float* a,
     int local_j = get_local_id(1);
     __local float buf[TILE_SIZE][TILE_SIZE];
 
-    buf[local_i][local_j] = a[i * k + j];
+    buf[local_i][local_j] = a[j * k + i];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    at[j * m + i] = buf[local_i][local_j];
+    int t_y = i + (local_j - local_i);
+    int t_x = j + (local_i - local_j);
+
+    at[t_y * k + t_x] = buf[local_j][local_i];
 }
 
 __kernel void matrix_transpose_local_good_banks(__global   const float* a,
@@ -58,9 +61,12 @@ __kernel void matrix_transpose_local_good_banks(__global   const float* a,
     int local_j = get_local_id(1);
     __local float buf[TILE_SIZE + 1][TILE_SIZE];
 
-    buf[local_i][local_j] = a[i * k + j];
+    buf[local_i][local_j] = a[j * k + i];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    at[j * m + i] = buf[local_i][local_j];
+    int t_y = i + (local_j - local_i);
+    int t_x = j + (local_i - local_j);
+
+    at[t_y * k + t_x] = buf[local_j][local_i];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -52,7 +52,7 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
 //    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(tile_size, tile_size, 1024, 1024);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -62,7 +62,7 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 {
 //    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(tile_size, tile_size, 1024, 1024);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -72,7 +72,7 @@ KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
 //    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(tile_size, tile_size / wpt, 1024, 1024 / wpt);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,9 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
+//    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, 1024, 1024);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +60,9 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
+//    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, 1024, 1024);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +70,9 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
+//    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, 1024, 1024 / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -143,8 +143,8 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
 
-    // TODO uncomment
-    return 0;
+//     TODO uncomment
+//    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -33,9 +33,14 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        unsigned group_size_x = 16;
+        unsigned group_size_y = 16;
+        unsigned work_size_x  = M;
+        unsigned work_size_y  = K;
+
+
+        gpu::WorkSize work_size(group_size_x, group_size_y, work_size_x, work_size_y);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -74,8 +79,7 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    // TODO uncomment
-    return 0;
+    //    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./matrixMultiplication
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz. Intel(R) Corporation. Total memory: 32573 Mb
  Device #1: GPU. Intel(R) UHD Graphics 750. Total memory: 13029 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 2.515+-0 s
CPU: 0.795229 GFlops
[naive, ts=4]
    GPU: 0.00766667+-0.000471405 s
    GPU: 260.87 GFlops
    Average difference: 0.0138686%
[naive, ts=8]
    GPU: 0.00266667+-0.000471405 s
    GPU: 750 GFlops
    Average difference: 0.0138686%
[naive, ts=16]
    GPU: 0.0025+-0.0005 s
    GPU: 800 GFlops
    Average difference: 0.0138686%
[local, ts=4]
    GPU: 0.00633333+-0.000471405 s
    GPU: 315.789 GFlops
    Average difference: 0.000196008%
[local, ts=8]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local, ts=16]
    GPU: 0.00116667+-0.000372678 s
    GPU: 1714.29 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=2]
    GPU: 0.00716667+-0.000372678 s
    GPU: 279.07 GFlops
    Average difference: 0.000196008%
[local wpt, ts=4, wpt=4]
    GPU: 0.0106667+-0.000471405 s
    GPU: 187.5 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=2]
    GPU: 0.00133333+-0.000471405 s
    GPU: 1500 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=4]
    GPU: 0.002+-0 s
    GPU: 1000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=8, wpt=8]
    GPU: 0.003+-4.1159e-11 s
    GPU: 666.667 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=2]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=4]
    GPU: 0.000833333+-0.000372678 s
    GPU: 2400 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=8]
    GPU: 0.000666667+-0.000471405 s
    GPU: 3000 GFlops
    Average difference: 0.000196008%
[local wpt, ts=16, wpt=16]
    GPU: 0.001+-0 s
    GPU: 2000 GFlops
    Average difference: 0.000196008%


$ ./matrixTranspose
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz. Intel(R) Corporation. Total memory: 32573 Mb
  Device #1: GPU. Intel(R) UHD Graphics 750. Total memory: 13029 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.00045+-0.000497494 s
    GPU: 37282.7 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.00035+-0.00047697 s
    GPU: 47934.9 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.00035+-0.00047697 s
    GPU: 47934.9 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./matrixMultiplication

OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.22282+-0 s
CPU: 0.321398 GFlops
[naive, ts=4]
    GPU: 0.226829+-0.00800876 s
    GPU: 8.81722 GFlops
    Average difference: 0.0124275%
[naive, ts=8]
    GPU: 0.22771+-0.0108459 s
    GPU: 8.78311 GFlops
    Average difference: 0.0124275%
[naive, ts=16]
    GPU: 0.199+-0.00652925 s
    GPU: 10.0503 GFlops
    Average difference: 0.0124275%
[local, ts=4]
    GPU: 0.595531+-0.00112262 s
    GPU: 3.35835 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.146772+-0.000291572 s
    GPU: 13.6265 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.0914913+-0.000117877 s
    GPU: 21.86 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.517437+-0.0010834 s
    GPU: 3.86521 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.428557+-0.000268414 s
    GPU: 4.66682 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.135555+-0.000631529 s
    GPU: 14.7541 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.144889+-0.000342389 s
    GPU: 13.8037 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.133024+-0.000282424 s
    GPU: 15.0349 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.078622+-0.00056023 s
    GPU: 25.4382 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0805215+-0.000161065 s
    GPU: 24.8381 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.0827825+-0.000277813 s
    GPU: 24.1597 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0899+-0.000161505 s
    GPU: 22.2469 GFlops
    Average difference: 0.000149043%

$ ./matrixTranspose

OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0153302+-7.66767e-05 s
    GPU: 1094.39 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.02381+-0.000349663 s
    GPU: 704.628 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0239231+-0.000329043 s
    GPU: 701.298 millions/s
</pre>

</p></details>