### PR TITLE
Task05 Артем Сидоренко HSE

### DIFF
--- a/src/cl/merge.cl
+++ b/src/cl/merge.cl
@@ -5,9 +5,36 @@
 #line 5
 
 
+int bsearch(__global const int *a, unsigned int len, int key, int even) {
+    int l = 0;
+    int r = len;
+    while (l < r) {
+        int m = (l + r) / 2;
+        if (a[m] < key || (even && a[m] == key)) {
+            l = m + 1;
+        } else {
+            r = m;
+        }
+    }
+    return l;
+}
+
 __kernel void merge_global(__global const int *as, __global int *bs, unsigned int block_size)
 {
+    int gid = get_global_id(0);
 
+    int pos_in_first = gid % block_size;
+    unsigned int first_begin = (gid / block_size) * block_size;
+    __global const int* first = as + first_begin;
+
+    int parity = (gid / block_size) % 2;
+    __global const int* second =  parity ? first - block_size : first + block_size;
+    int pos_in_second = bsearch(second, block_size, as[gid], parity);
+
+    int pair_begin = (gid / (2 * block_size)) * (2 * block_size);
+//    printf("Calculated parity %d, pair_begin %d, pos_in_first %d, pos_in_second %d for gid %d, key %d\n", parity, pair_begin, pos_in_first, pos_in_second, gid, as[gid]);
+
+    bs[pair_begin + pos_in_first + pos_in_second] = as[gid];
 }
 
 __kernel void calculate_indices(__global const int *as, __global unsigned int *inds, unsigned int block_size)

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
             t.restart();
-            gpu::WorkSize ws(16, n);
+            gpu::WorkSize ws(128, n);
             for (int block_size = 1; block_size < n; block_size *= 2) {
                 merge_global.exec(ws, as_gpu, bs_gpu, block_size);
                 as_gpu.swap(bs_gpu);

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -58,9 +58,6 @@ int main(int argc, char **argv) {
 
     const std::vector<int> cpu_sorted = computeCPU(as);
 
-    // remove me for task 5.1
-    return 0;
-
     gpu::gpu_mem_32i as_gpu;
     gpu::gpu_mem_32i bs_gpu;
 
@@ -75,7 +72,11 @@ int main(int argc, char **argv) {
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
             t.restart();
-            // TODO
+            gpu::WorkSize ws(16, n);
+            for (int block_size = 1; block_size < n; block_size *= 2) {
+                merge_global.exec(ws, as_gpu, bs_gpu, block_size);
+                as_gpu.swap(bs_gpu);
+            }
             t.nextLap();
         }
         std::cout << "GPU global: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\merge.exe 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Data generated for n=33554432!
CPU: 10.643+-0 s
CPU: 3.10062 millions/s
GPU global: 0.0518527+-0.00195273 s
GPU global: 636.419 millions/s

Process finished with exit code 0
</pre>
Run ./merge
        OpenCL devices:
Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
        Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
        Data generated for n=33554432!
CPU: 2.78069+-0 s
        CPU: 11.8676 millions/s
        GPU global: 5.75844+-0.00843888 s
        GPU global: 5.73072 millions/s
</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./merge
OpenCL devices:
    Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.78069+-0 s
CPU: 11.8676 millions/s
GPU global: 5.75844+-0.00843888 s
GPU global: 5.73072 millions/s
</pre>

</p></details>

Кажись тут очень тупое решение и не самое оптимальное в плане code divergency и тд. Можно попробовать засунуть в одну рабочую группу только правые массивы (и еще раз прогнать только на левых), условно, чтобы одинаковый код гонялся (сейчас там в одной рабочей группе вперешку правые и левые массивы, для которых логика различается слегка). Но у меня лапки)