### PR TITLE
Task06 Даниил Ушков ITMO 

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,24 @@
-__kernel void bitonic()
+__kernel void bitonic(__global int *as, __global int *bs, int n, int block_size)
 {
+    unsigned int gid = get_global_id(0);
+    unsigned int block_idx = gid / (block_size / 2);
+    unsigned int inblock_idx = gid % (block_size / 2);
+    unsigned int idx1 = block_size * block_idx;
+    unsigned int idx2 = block_size * block_idx + block_size / 2;
 
+    if (idx2 >= n) {
+        return;
+    }
+
+    if (block_idx % 2 == 0) {
+        if (as[idx1] > as[idx2]) {
+            bs[idx1] = as[idx2];
+            bs[idx2] = as[idx1];
+        }
+    } else {
+        if (as[idx2] > as[idx1]) {
+            bs[idx1] = as[idx2];
+            bs[idx2] = as[idx1];
+        }
+    }
 }

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -13,21 +13,11 @@ __kernel void bitonic(__global int *as, __global int *bs, int n, int big_block_s
         return;
     }
 
-    if (big_block_idx % 2 == 0) {
-        if (as[idx1] > as[idx2]) {
-            bs[idx1] = as[idx2];
-            bs[idx2] = as[idx1];
-        } else {
-            bs[idx1] = as[idx1];
-            bs[idx2] = as[idx2];
-        }
+    if ((big_block_idx % 2 == 0 && as[idx1] > as[idx2]) || (big_block_idx % 2 == 1 && as[idx1] < as[idx2])) {
+        bs[idx1] = as[idx2];
+        bs[idx2] = as[idx1];
     } else {
-        if (as[idx2] > as[idx1]) {
-            bs[idx1] = as[idx2];
-            bs[idx2] = as[idx1];
-        } else {
-            bs[idx1] = as[idx1];
-            bs[idx2] = as[idx2];
-        }
+        bs[idx1] = as[idx1];
+        bs[idx2] = as[idx2];
     }
 }

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,4 @@
-__kernel void bitonic(__global int *as, __global int *bs, int n, int big_block_size, int small_block_size)
+__kernel void bitonic(__global int *as, __global int *bs, int n, unsigned int big_block_size, unsigned int small_block_size)
 {
     unsigned int gid = get_global_id(0);
     unsigned int big_block_idx = gid / (big_block_size / 2);

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,24 +1,33 @@
-__kernel void bitonic(__global int *as, __global int *bs, int n, int block_size)
+__kernel void bitonic(__global int *as, __global int *bs, int n, int big_block_size, int small_block_size)
 {
     unsigned int gid = get_global_id(0);
-    unsigned int block_idx = gid / (block_size / 2);
-    unsigned int inblock_idx = gid % (block_size / 2);
-    unsigned int idx1 = block_size * block_idx;
-    unsigned int idx2 = block_size * block_idx + block_size / 2;
+    unsigned int big_block_idx = gid / (big_block_size / 2);
+    unsigned int big_block_local_idx = gid % (big_block_size / 2);
+    unsigned int small_block_idx = big_block_local_idx / (small_block_size / 2);
+    unsigned int small_block_local_idx = big_block_local_idx % (small_block_size / 2);
+
+    unsigned int idx1 = big_block_size * big_block_idx + small_block_size * small_block_idx + small_block_local_idx;
+    unsigned int idx2 = big_block_size * big_block_idx + small_block_size * small_block_idx + small_block_local_idx + small_block_size / 2;
 
     if (idx2 >= n) {
         return;
     }
 
-    if (block_idx % 2 == 0) {
+    if (big_block_idx % 2 == 0) {
         if (as[idx1] > as[idx2]) {
             bs[idx1] = as[idx2];
             bs[idx2] = as[idx1];
+        } else {
+            bs[idx1] = as[idx1];
+            bs[idx2] = as[idx2];
         }
     } else {
         if (as[idx2] > as[idx1]) {
             bs[idx1] = as[idx2];
             bs[idx2] = as[idx1];
+        } else {
+            bs[idx1] = as[idx1];
+            bs[idx2] = as[idx2];
         }
     }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -72,10 +72,10 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            for (int big_block_size = 2; big_block_size < 2 * n; big_block_size *= 2) {
+            for (unsigned int big_block_size = 2; big_block_size < 2 * n; big_block_size *= 2) {
                 unsigned int big_block_count = (n + big_block_size - 1) / big_block_size;
                 gpu::WorkSize work_size{64, big_block_count * (big_block_size / 2)};
-                for (int small_block_size = big_block_size; small_block_size > 1; small_block_size /= 2) {
+                for (unsigned int small_block_size = big_block_size; small_block_size > 1; small_block_size /= 2) {
                     bitonic.exec(work_size, as_gpu, bs_gpu, n, big_block_size, small_block_size);
                     std::swap(as_gpu, bs_gpu);
                 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -13,7 +13,7 @@
 
 const int benchmarkingIters = 10;
 const int benchmarkingItersCPU = 1;
-const unsigned int n = 8; //32 * 1024 * 1024;
+const unsigned int n = 32 * 1024 * 1024;
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
@@ -72,10 +72,13 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            for (int block_size = 2; block_size >= 2 * n; block_size *= 2) {
-                gpu::WorkSize work_size{64, (n + block_size - 1) / block_size / 2};
-                bitonic.exec(work_size, as_gpu, bs_gpu, n, block_size);
-                std::swap(as_gpu, bs_gpu);
+            for (int big_block_size = 2; big_block_size < 2 * n; big_block_size *= 2) {
+                unsigned int big_block_count = (n + big_block_size - 1) / big_block_size;
+                gpu::WorkSize work_size{64, big_block_count * (big_block_size / 2)};
+                for (int small_block_size = big_block_size; small_block_size > 1; small_block_size /= 2) {
+                    bitonic.exec(work_size, as_gpu, bs_gpu, n, big_block_size, small_block_size);
+                    std::swap(as_gpu, bs_gpu);
+                }
             }
 
             t.nextLap();


### PR DESCRIPTION
```
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-1260P. Intel(R) Corporation. Total memory: 31716 Mb
Using device #0: CPU. 12th Gen Intel(R) Core(TM) i7-1260P. Intel(R) Corporation. Total memory: 31716 Mb
Data generated for n=33554432!
CPU: 8.09729+-0 s
CPU: 4.07544 millions/s
GPU: 4.809+-0.00459325 s
GPU: 6.86213 millions/s
```

Видим, что производительность примерно в два раза хуже, чем у merge sort. Возможно это связано с количеством задействованных потоков: в случае merge sort их было `n` (ровно по количеству элементов в массиве), когда как в bitonic sort их `n/2`.