### PR TITLE
Task06 Валерий Мацкевич HSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build
 cmake-build*
 .vs
+.history
+.vscode

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,25 @@
-__kernel void bitonic()
+__kernel void bitonic(__global int *as, unsigned int block_size, unsigned int depth)
 {
+    const size_t gid = get_global_id(0);
+    const size_t sequence_size = block_size >> depth;
+    const size_t sequence_index = gid / (sequence_size / 2);
+    const size_t sequence_offset = gid % (sequence_size / 2);
 
+    const size_t i1 = sequence_index * sequence_size + sequence_offset;
+    const size_t i2 = i1 + sequence_size / 2;
+
+    const int lhs = as[i1];
+    const int rhs = as[i2];
+
+    if ((gid / (block_size / 2)) % 2 == 0) {
+        if (lhs > rhs) {
+            as[i1] = rhs;
+            as[i2] = lhs;
+        }
+    } else {
+        if (lhs < rhs) {
+            as[i1] = rhs;
+            as[i2] = lhs;
+        }
+    }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -25,8 +25,7 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
-std::vector<int> computeCPU(const std::vector<int> &as)
-{
+std::vector<int> computeCPU(const std::vector<int> &as) {
     std::vector<int> cpu_sorted;
 
     timer t;
@@ -58,9 +57,6 @@ int main(int argc, char **argv) {
 
     const std::vector<int> cpu_sorted = computeCPU(as);
 
-    // remove me
-    return 0;
-
     gpu::gpu_mem_32i as_gpu;
     as_gpu.resizeN(n);
 
@@ -73,7 +69,12 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            /*TODO*/
+            gpu::WorkSize workSize(64, n / 2);
+            for (unsigned int blockSize = 1u, logBlockSize = 0u; blockSize <= n; blockSize *= 2u, logBlockSize++) {
+                for (unsigned int depth = 0; depth < logBlockSize; depth++) {
+                    bitonic.exec(workSize, as_gpu, blockSize, depth);
+                }
+            }
 
             t.nextLap();
         }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./build/bitonic 
OpenCL devices:
  Device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
Using device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
Data generated for n=33554432!
CPU: 10.6981+-0 s
CPU: 3.08467 millions/s
GPU: 9.11155+-0.361273 s
GPU: 3.62178 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
./bitonic
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.69383+-0 s
CPU: 12.2502 millions/s
GPU: 11.1962+-0.00321382 s
GPU: 2.94744 millions/s
</pre>

</p></details>

На GPU возможности запустить нет, а мой CPU опять выдаёт непредсказуемые результаты в single-core режиме. На серверном же CPU деградация производительности выше при параллелизации, чем на десктопном, потому что, скорее всего, никакие потоки и NUMA-ноды не прибивает OpenCL, отчего с увеличением числа потоков перформанс падает. На mergesort каждый поток в рамках одного вызова кернела выполняет больше работы, поэтому, думаю, оверхед на tasks ниже, чем в случае bitonicsort