### PR TITLE
Task06 Даниил Русов ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,32 @@
-__kernel void bitonic()
+__kernel void bitonic(__global int* as, unsigned int max_K, unsigned int K, unsigned int n)
 {
+	
+	unsigned int gidx = get_global_id(0);
+	unsigned int block_size = 2 * K;
+	unsigned int block_idx = gidx / K;
+	
+	unsigned int arrow_in_block = gidx % K;
+	
+	unsigned int first = block_idx * block_size + arrow_in_block;
+	unsigned int second = first + K;
+	if (second >= n || first >= n)
+		return;
+	
+	int first_value = as[first];
+	int second_value = as[second];
+	
+	bool asc = ((gidx / max_K) % 2) == 0;
+	
+	if (first_value > second_value && asc)
+	{
+		as[second] = first_value;
+		as[first] = second_value;
+	}
 
+	if (first_value < second_value && !asc)
+	{
+		as[second] = first_value;
+		as[first] = second_value;
+	}
+	
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     const std::vector<int> cpu_sorted = computeCPU(as);
 
     // remove me
-    return 0;
+    //return 0;
 
     gpu::gpu_mem_32i as_gpu;
     as_gpu.resizeN(n);
@@ -73,8 +73,14 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            /*TODO*/
-
+            for (int max_K = 1; max_K <= n / 2; max_K *= 2) 
+            {
+                for (unsigned int K = max_K; K >= 1; K /= 2) 
+                {
+                    unsigned int N = n / K;
+                    bitonic.exec(gpu::WorkSize(64, n / 2), as_gpu, max_K, K, n);
+                }
+            }
             t.nextLap();
         }
 


### PR DESCRIPTION
Merge sort в 3 раза быстрее, чем bitonic, хотя сравнений должно быть столько же. Возможно играет роль большее число синхронизаций с CPU (в merge внутренний цикл бинпоиска проходит внутри кернела).

<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16011 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6404 Mb
  Device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
Using device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
Data generated for n=33554432!
CPU: 13.6455+-0 s
CPU: 2.41838 millions/s
GPU: 0.323032+-0.000354991 s
GPU: 102.157 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.75146+-0 s
CPU: 11.9936 millions/s
GPU: 11.3515+-0.0127874 s
GPU: 2.90711 millions/s
</pre>

</p></details>