### PR TITLE
Task06 Дениль Шарипов СПбГУ

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,22 @@
-__kernel void bitonic()
-{
+void swap(__global int* a, __global int* b) {
+    int tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
 
+__kernel void bitonic(__global int* as, unsigned int block_size, unsigned int subblock_size)
+{
+    int gid = get_global_id(0);
+    int block_idx = gid % (2 * block_size);
+    int subblock_idx = gid % (2 * subblock_size);
+
+    if (block_idx < block_size && subblock_idx < subblock_size) {
+        if (as[gid] > as[gid + subblock_size]) {
+            swap(&as[gid], &as[gid + subblock_size]);
+        }
+    } else if (block_idx >= block_size && subblock_idx >= subblock_size) {
+        if (as[gid] > as[gid - subblock_size]) {
+            swap(&as[gid], &as[gid - subblock_size]);
+        }
+    }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -58,9 +58,6 @@ int main(int argc, char **argv) {
 
     const std::vector<int> cpu_sorted = computeCPU(as);
 
-    // remove me
-    return 0;
-
     gpu::gpu_mem_32i as_gpu;
     as_gpu.resizeN(n);
 
@@ -73,7 +70,11 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            /*TODO*/
+            for (int block_size = 2; block_size <= n; block_size *= 2) {
+                for (int subblock_size = block_size / 2; subblock_size >= 1; subblock_size /= 2) {
+                    bitonic.exec(gpu::WorkSize(128, n), as_gpu, block_size, subblock_size);
+                }
+            }
 
             t.nextLap();
         }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Data generated for n=33554432!
CPU: 17.4429+-0 s
CPU: 1.89189 millions/s
GPU: 3.86333+-0.0256939 s
GPU: 8.54185 millions/s
</pre>

</p></details>
<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.72869+-0 s
CPU: 12.0937 millions/s
GPU: 20.4463+-0.010382 s
GPU: 1.61399 millions/s
</pre>

</p></details>

Bitonic sort работает примерно в 2 раза быстрее, чем Merge sort. Это можно объяснить тем, что Bitonic sort более cache-friendly, нежели Merge sort, который "гуляет" по оперативной памяти из-за своих бинпоисков. Ну и скорее всего на cpu оверхед от синхронизаций не такой большой, как на gpu, поэтому Bitonic sort не сильно от этого страдает.