### PR TITLE
Task06 Роман Гостило HSE

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -5,15 +5,15 @@
 #endif
 
 #line 6
-__kernel void bitonic(__global int *as, unsigned int block_size, unsigned int max_block_size) {
+__kernel void bitonic(__global int *as, unsigned int block_size_log, unsigned int max_block_size_log) {
     int global_id = get_global_id(0);
 
-    int half_block_size = block_size / 2;
-    int block_id = global_id / half_block_size;
-    int max_block_id = global_id / (max_block_size / 2);
-    int is_increasing = (max_block_id % 2 == 0);
+    int half_block_size = (1 << (block_size_log)) >> 1;
+    int block_id = global_id >> (block_size_log - 1);
+    int max_block_id = global_id >> (max_block_size_log - 1);
+    int is_increasing = (max_block_id & 1) ^ 1;
 
-    int arr_id = global_id + block_id * half_block_size;
+    int arr_id = global_id + (block_id << (block_size_log - 1));
 
     int left_elem = as[arr_id];
     int right_elem = as[arr_id + half_block_size];

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -16,13 +16,11 @@ __kernel void bitonic(__global int *as, unsigned int block_size, unsigned int ma
 
     int arr_id = global_id + block_id * half_block_size;
 
-//    printf("comparing lhs_id=%d rhs_id=%d lhs=%d rhs=%d is_increasing=%d block_size=%d\n",
-//           arr_id, arr_id + half_block_size, as[arr_id], as[arr_id + half_block_size], is_increasing, block_size);
-    if ((is_increasing && as[arr_id] > as[arr_id + half_block_size])
-        || (!is_increasing && as[arr_id] < as[arr_id + half_block_size])) {
-//        printf("swap\n");
-        unsigned int tmp = as[arr_id + half_block_size];
-        as[arr_id + half_block_size] = as[arr_id];
-        as[arr_id] = tmp;
+    int left_elem = as[arr_id];
+    int right_elem = as[arr_id + half_block_size];
+
+    if ((left_elem < right_elem) != is_increasing) {
+        as[arr_id] = right_elem;
+        as[arr_id + half_block_size] = left_elem;
     }
 }

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -9,7 +9,6 @@ __kernel void bitonic(__global int *as, unsigned int block_size, unsigned int ma
     int global_id = get_global_id(0);
 
     int half_block_size = block_size / 2;
-
     int block_id = global_id / half_block_size;
     int max_block_id = global_id / (max_block_size / 2);
     int is_increasing = (max_block_id % 2 == 0);

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,28 @@
-__kernel void bitonic()
-{
+#ifdef __CLION_IDE__
 
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#line 6
+__kernel void bitonic(__global int *as, unsigned int block_size, unsigned int max_block_size) {
+    int global_id = get_global_id(0);
+
+    int half_block_size = block_size / 2;
+
+    int block_id = global_id / half_block_size;
+    int max_block_id = global_id / (max_block_size / 2);
+    int is_increasing = (max_block_id % 2 == 0);
+
+    int arr_id = global_id + block_id * half_block_size;
+
+//    printf("comparing lhs_id=%d rhs_id=%d lhs=%d rhs=%d is_increasing=%d block_size=%d\n",
+//           arr_id, arr_id + half_block_size, as[arr_id], as[arr_id + half_block_size], is_increasing, block_size);
+    if ((is_increasing && as[arr_id] > as[arr_id + half_block_size])
+        || (!is_increasing && as[arr_id] < as[arr_id + half_block_size])) {
+//        printf("swap\n");
+        unsigned int tmp = as[arr_id + half_block_size];
+        as[arr_id + half_block_size] = as[arr_id];
+        as[arr_id] = tmp;
+    }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -11,7 +11,6 @@
 #include <stdexcept>
 #include <vector>
 
-const bool debug_print = false;
 const int benchmarkingIters = 10;
 const int benchmarkingItersCPU = 1;
 const unsigned int n = 32 * 1024 * 1024;
@@ -70,9 +69,9 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            for (unsigned int max_block_size = 2; max_block_size <= n; max_block_size *= 2) {
-                for (unsigned int block_size = max_block_size; block_size >= 2; block_size /= 2) {
-                    bitonic.exec(gpu::WorkSize(64, n / 2), as_gpu, block_size, max_block_size);
+            for (unsigned int max_block_size_log = 1; (1 << max_block_size_log) <= n; ++max_block_size_log) {
+                for (unsigned int block_size_log = max_block_size_log; (1 << block_size_log) <= n; --block_size_log) {
+                    bitonic.exec(gpu::WorkSize(64, n / 2), as_gpu, block_size_log, max_block_size_log);
                     as_gpu.readN(as.data(), n);
                 }
             }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -58,16 +58,6 @@ int main(int argc, char **argv) {
     std::cout << "Data generated for n=" << n << "!" << std::endl;
 
     const std::vector<int> cpu_sorted = computeCPU(as);
-
-    if (debug_print) {
-        printf("init ");
-        for (int i = 0; i < n; ++i) {
-            printf("%d ", as[i]);
-        }
-        printf("\n");
-    }
-
-
     gpu::gpu_mem_32i as_gpu;
     as_gpu.resizeN(n);
 
@@ -82,16 +72,8 @@ int main(int argc, char **argv) {
 
             for (unsigned int max_block_size = 2; max_block_size <= n; max_block_size *= 2) {
                 for (unsigned int block_size = max_block_size; block_size >= 2; block_size /= 2) {
-                    bitonic.exec(gpu::WorkSize(2, n / 2), as_gpu, block_size, max_block_size);
+                    bitonic.exec(gpu::WorkSize(64, n / 2), as_gpu, block_size, max_block_size);
                     as_gpu.readN(as.data(), n);
-                    if (debug_print) {
-                        printf("step %d ", block_size);
-                        for (int i = 0; i < n; ++i) {
-                            printf("%d ", as[i]);
-                        }
-                        printf("\n");
-                    }
-
                 }
             }
 


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Data generated for n=33554432!
CPU: 2.76277+-1.67658e-08 s
CPU: 11.9445 millions/s
GPU: 1.83902+-8.0996e-09 s
GPU: 17.9443 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.69585+-0 s
CPU: 12.241 millions/s
GPU: 6.81797+-0.0193843 s
GPU: 4.84015 millions/s

</pre>

</p></details>

bitonic sort на CPU примерно в полтора раза быстрее, чем merge sort. Оно и понятно: мы используем вдвое меньше потоков и не бегаем по видеопамяти в непредсказуемой манере. Проверить на GPU возможности нет :(

btw: замена деления/умножения на 2 на битовые сдвиги увеличила производительность bitonic sort в полтора раза, и я отчаянно не понимаю почему. Компилятор кернелов не может понять, что деление на 2 - это битовый сдвиг?

btw2: заменил деления на битовые сдвиги в merge_sort, получился прирост в 10% где-то