### PR TITLE
Task06 Андрей Гладких ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,15 @@
-__kernel void bitonic()
+__kernel void bitonic(__global int *as, unsigned int n, unsigned int k, unsigned int j)
 {
+    const unsigned int i = get_global_id(0);
 
+    const unsigned int l = i ^ j;
+
+    if (l > i) {
+        if ((((i & k) == 0) && (as[i] > as[l])) ||
+        (((i & k) != 0) && (as[i] < as[l]))) {
+            const int tmp = as[l];
+            as[l] = as[i];
+            as[i] = tmp;
+        }
+    }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -58,9 +58,6 @@ int main(int argc, char **argv) {
 
     const std::vector<int> cpu_sorted = computeCPU(as);
 
-    // remove me
-    return 0;
-
     gpu::gpu_mem_32i as_gpu;
     as_gpu.resizeN(n);
 
@@ -73,7 +70,11 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            /*TODO*/
+            for (unsigned int k = 2; k <= n; k *= 2) {
+                for (unsigned int j = k / 2; j > 0; j /= 2) {
+                    bitonic.exec(gpu::WorkSize(128, n), as_gpu, n, k, j);
+                }
+            }
 
             t.nextLap();
         }


### PR DESCRIPTION
```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800X 8-Core Processor             . Intel(R) Corporation. Total memory: 32670 Mb
  Device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Using device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Data generated for n=33554432!
CPU: 11.752+-0 s
CPU: 2.80804 millions/s
GPU: 0.125586+-0.000764128 s
GPU: 262.767 millions/s
```

<details><summary>Для сравнения вывод Merge Sort</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800X 8-Core Processor             . Intel(R) Corporation. Total memory: 32670 Mb
  Device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Using device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Data generated for n=33554432!
CPU: 11.3544+-0 s
CPU: 2.90637 millions/s
GPU global: 0.0195197+-0.000327024 s
GPU global: 1690.6 millions/s
</pre>

</p></details>

Получается, что bitonic sort в ~6.45 раз медленнее, чем merge sort. Скорее всего, это связано с увеличением количества запусков kernel'а (т.е. глобальных синхронизаций между сортировками группы подблоков) - их в log(n) больше раз (второй цикл в CPU коде, который отвечает за постепенное уменьшение размера подблоков).

Ещё интерсно, что в нашем случае замедление должно было составить `log(32 * 1024 * 1024) ~ 7.52`, что близко к тому, что получилось на практике.