### PR TITLE
Task06 Илья Болкисев ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,26 @@
-__kernel void bitonic()
+__kernel void bitonic(__global int *data, const unsigned int stage, const unsigned int passOfStage)
 {
+    const unsigned int gidx = get_global_id(0);
 
+    unsigned int internalIdx;
+    unsigned int secondIdx;
+
+    if (passOfStage > 1) {
+        internalIdx = (gidx / (passOfStage / 2)) * passOfStage + (gidx % (passOfStage / 2));
+        secondIdx = internalIdx + (passOfStage / 2);
+    }
+    else {
+        internalIdx = gidx;
+        secondIdx = internalIdx + 1;
+    }
+
+    int first = data[internalIdx];
+    int second = data[secondIdx];
+
+    int direction = ((gidx / (stage / 2)) % 2) == 0 ? 1 : 0; // 1 - возрастающая, 0 - убывающая
+
+    if ( (direction && first > second) || (!direction && first < second) ) {
+        data[internalIdx] = second;
+        data[secondIdx] = first;
+    }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -58,9 +58,6 @@ int main(int argc, char **argv) {
 
     const std::vector<int> cpu_sorted = computeCPU(as);
 
-    // remove me
-    return 0;
-
     gpu::gpu_mem_32i as_gpu;
     as_gpu.resizeN(n);
 
@@ -73,7 +70,19 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            /*TODO*/
+            for (unsigned int stage = 2; stage <= n; stage *= 2) {
+                for (unsigned int passOfStage = stage; passOfStage > 1; passOfStage /= 2) {
+                    size_t local_size = 256;
+                    size_t global_size = n / 2 + n % 2;
+
+                    bitonic.exec(
+                        gpu::WorkSize(local_size, global_size),
+                        as_gpu,
+                        stage,
+                        passOfStage
+                    );
+                }
+            }
 
             t.nextLap();
         }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
/home/realist/CLionProjects/GPGPUTasks2024/cmake-build-debug/bitonic 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz. Intel(R) Corporation. Total memory: 32028 Mb
  Device #1: GPU. NVIDIA GeForce RTX 2070 SUPER. Total memory: 7973 Mb
Using device #1: GPU. NVIDIA GeForce RTX 2070 SUPER. Total memory: 7973 Mb
Data generated for n=33554432!
CPU: 11.1357+-0 s
CPU: 2.96345 millions/s
GPU: 0.183927+-0.00039314 s
GPU: 179.419 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./bitonic
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.73093+-0 s
CPU: 12.0838 millions/s
GPU: 11.2083+-0.00677755 s
GPU: 2.94425 millions/s
</pre>

</p></details>

Сравнение: bitonic sort оказался в медленнее чем merge sort: на GPU в ~3 раза, на CPU в ~2 раза.