### PR TITLE
Task06 Алсу Верещагина ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,16 @@
-__kernel void bitonic()
+__kernel void bitonic(__global int *as, unsigned int block_half_size, unsigned int sub_block_half_size)
 {
+    unsigned int gid = get_global_id(0);
+    unsigned int block_index = block_index = gid / block_half_size;
+    bool is_growing = block_index % 2 == 0;
+    unsigned int idx = gid / sub_block_half_size * (sub_block_half_size * 2) + (gid % sub_block_half_size);
 
+    unsigned int pair_index = idx + sub_block_half_size;
+    if (is_growing && as[idx] > as[pair_index] ||
+        !is_growing && as[idx] < as[pair_index]
+    ) {
+        int tmp = as[idx];
+        as[idx] = as[pair_index];
+        as[pair_index] = tmp;
+    }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
# ./bitonic 1
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 24028 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1080. Total memory: 8106 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1080. Total memory: 8106 Mb
Data generated for n=33554432!
CPU: 22.3502+-0 s
CPU: 1.4765 millions/s
2 warnings generated.
GPU: 0.283568+-4.84034e-05 s
GPU: 116.374 millions/s

</pre>

</p></details>

Ожидалось, что bitonic sort будет быстрее, чем merge sort, так как тут идут последовательные обращения к соседним элементам. Однако, в реализации на том же размере рабочей группы, что и merge sort, скорость bitonic sort получилась примерно в 3 раза ниже. Сокращение количества потоков в половину от длины массива (так, чтобы каждый поток делал сравнение) дало лишь незначительный прирост скорости.