### PR TITLE
Task04 Анна Волгина ITMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build
 cmake-build*
 .vs
+.vscode/

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,100 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(__global float *a, 
+                                        __global float *b, 
+                                        __global float *c, 
+                                        unsigned int M, 
+                                        unsigned int K, 
+                                        unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k) {
+        sum += a[j * K + k] * b[k * N + i];
+    }
+    c[j * N + i] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(__global float *a, 
+                                        __global float *b, 
+                                        __global float *c, 
+                                        unsigned int M, 
+                                        unsigned int K, 
+                                        unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+
+    for (int t = 0; t * TILE_SIZE < K; t++) {
+        tileA[lj][li] = a[j * K + (t * TILE_SIZE + li)];
+        tileB[lj][li] = b[(t * TILE_SIZE + lj) * N + i];
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            sum += tileA[lj][k] * tileB[k][li];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    
+    c[j * N + i] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(__global float *a, 
+                                        __global float *b, 
+                                        __global float *c, 
+                                        unsigned int M, 
+                                        unsigned int K, 
+                                        unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        sum[w] = 0;
+    }
+
+    for (int t = 0; t * TILE_SIZE < K; t++) {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            tileA[lj * WORK_PER_THREAD + w][li] = a[(j * WORK_PER_THREAD + w) * K + (t * TILE_SIZE + li)];
+            tileB[lj * WORK_PER_THREAD + w][li] = b[(t * TILE_SIZE + (lj * WORK_PER_THREAD + w)) * N + i];
+        }
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            for (int k = 0; k < TILE_SIZE; ++k) {
+                sum[w] += tileA[lj * WORK_PER_THREAD + w][k] * tileB[k][li];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    
+    for(int w = 0; w < WORK_PER_THREAD; w++) {
+        c[(j * WORK_PER_THREAD + w) * N + i] = sum[w];
+    }
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -5,17 +5,42 @@
 
 #line 6
 
-__kernel void matrix_transpose_naive()
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose_naive(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    float x = a[j * k + i];
+    at[i * m + j] = x;
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+__kernel void matrix_transpose_local_bad_banks(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    __local float tile[TILE_SIZE][TILE_SIZE]; 
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+    
+    tile[lj][li] = a[j * k + i];
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[(i - li + lj) * m + j - lj + li] = tile[li][lj];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+__kernel void matrix_transpose_local_good_banks(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    __local float tile[TILE_SIZE][TILE_SIZE + 1]; 
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+    
+    tile[lj][li] = a[j * k + i];
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[(i - li + lj) * m + j - lj + li] = tile[li][lj];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, N);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, N / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -144,7 +141,6 @@ int main(int argc, char **argv)
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
 
     // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -13,6 +13,7 @@
 const int benchmarkingIters = 100;
 const unsigned int M = 4096;
 const unsigned int K = 4096;
+const unsigned int WORK_GROUP = 16;
 
 void runTest(const std::string &kernel_name, const float *as)
 {
@@ -33,9 +34,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(WORK_GROUP, WORK_GROUP, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -73,9 +73,6 @@ int main(int argc, char **argv)
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
Результат транспонирования:
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz. Intel(R) Corporation. Total memory: 6244 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz. Intel(R) Corporation. Total memory: 6244 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0266513+-0.002003 s
    GPU: 629.509 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0242897+-0.00326094 s
    GPU: 690.713 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0244041+-0.0020234 s
    GPU: 687.476 millions/s
</pre>
При использовании локальной памяти производительность немного лучше, bad banking не повлиял.
  
Результат умножения:
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz. Intel(R) Corporation. Total memory: 6244 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz. Intel(R) Corporation. Total memory: 6244 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 15.0418+-0 s
CPU: 0.132962 GFlops
[naive, ts=4]
    GPU: 0.280661+-0.00925533 s
    GPU: 7.12604 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.291048+-0.00561721 s
    GPU: 6.87173 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.304985+-0.0164448 s
    GPU: 6.5577 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.673779+-0.0564847 s
    GPU: 2.96833 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.253431+-0.0570462 s
    GPU: 7.89168 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.180054+-0.0296535 s
    GPU: 11.1078 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.983655+-0.227027 s
    GPU: 2.03323 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.544898+-0.029863 s
    GPU: 3.67041 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.180149+-0.0064407 s
    GPU: 11.1019 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.153981+-0.00242313 s
    GPU: 12.9886 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.156303+-0.00847508 s
    GPU: 12.7957 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0728242+-0.00295777 s
    GPU: 27.4634 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0912872+-0.00767697 s
    GPU: 21.9089 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.095459+-0.00440464 s
    GPU: 20.9514 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0784765+-0.00215003 s
    GPU: 25.4853 GFlops
    Average difference: 0.000149043%
</pre>
При переходе от наивной к локальной версии при ts = 4 производительность ухудшилась, при ts = 8 не изменилась, при ts = 16 улучшилась. При добавлении wpt при ts = 4 производительность не поменялась, при ts = 8 и ts = 16 выросла. Зависимость между wpt и производительностью сложно оценить по полученным результатам.