### PR TITLE
Task07 Леонид Тернопол SPbU

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,32 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include "clion_defines.cl"
+
+#endif
+
+#line 7
+
+inline void order(__global int *a, __global int *b, bool ge) {
+    int av = *a;
+    int bv = *b;
+
+    if ((av >= bv) != ge) {
+        *a = bv;
+        *b = av;
+    }
+}
+
+__kernel void prefix_sum1(__global const int *as, __global int *bs, unsigned int stride, unsigned int n) {
+    const unsigned int wid = get_global_id(0);
+    const unsigned int idx = wid;
+
+    if (idx >= n) return;
+    bs[idx] = as[idx] + (idx >= stride ? as[idx - stride] : 0);
+}
+
+__kernel void prefix_sum2(__global int *as, unsigned int off, unsigned int stride, unsigned int n) {
+    const unsigned int wid = get_global_id(0);
+    const unsigned int idx = off + 2 * stride * (wid + 1) - 1;
+    if (idx >= n) return;
+    as[idx] += as[idx - stride];
+}


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./prefix_sum 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 7840HS with Radeon 780M Graphics   . Intel(R) Corporation. Total memory: 28356 Mb
  Device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14376/14537 Mb
Using device #1: GPU. AMD RadeonT 780M (gfx1103). Free memory: 14376/14537 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 3e-06+-0 s
CPU: 1365.33 millions/s
GPU: 0.000897+-0.000108844 s
GPU: 4.56633 millions/s
GPU [work-efficient]: 0.00169817+-0.000127894 s
GPU [work-efficient]: 2.41201 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.41667e-05+-1.86339e-06 s
CPU: 1156.52 millions/s
GPU: 0.00110067+-0.000141559 s
GPU: 14.8855 millions/s
GPU [work-efficient]: 0.0022435+-0.000183709 s
GPU [work-efficient]: 7.30287 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.3e-05+-0 s
CPU: 1524.09 millions/s
GPU: 0.00178417+-0.00012167 s
GPU: 36.732 millions/s
GPU [work-efficient]: 0.002635+-0.000131418 s
GPU [work-efficient]: 24.8713 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000172+-2.23607e-06 s
CPU: 1524.09 millions/s
GPU: 0.00253033+-7.78988e-05 s
GPU: 103.601 millions/s
GPU [work-efficient]: 0.00310617+-0.000155786 s
GPU [work-efficient]: 84.3947 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000682+-5.56776e-06 s
CPU: 1537.5 millions/s
GPU: 0.004803+-0.000232907 s
GPU: 218.317 millions/s
GPU [work-efficient]: 0.00497733+-0.000106306 s
GPU [work-efficient]: 210.67 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.002789+-5.35599e-05 s
CPU: 1503.87 millions/s
GPU: 0.0131837+-0.000388475 s
GPU: 318.144 millions/s
GPU [work-efficient]: 0.0116715+-0.0001394 s
GPU [work-efficient]: 359.363 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0117527+-0.000499763 s
CPU: 1427.52 millions/s
GPU: 0.0559487+-0.0022261 s
GPU: 299.868 millions/s
GPU [work-efficient]: 0.036583+-0.0005423 s
GPU [work-efficient]: 458.607 millions/s

Process finished with exit code 0
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./prefix_sum
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 6e-06+-0 s
CPU: 682.667 millions/s
GPU: 0.000145667+-3.81517e-06 s
GPU: 28.119 millions/s
GPU [work-efficient]: 0.000187333+-2.0548e-06 s
GPU [work-efficient]: 21.8648 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 2.43333e-05+-4.71405e-07 s
CPU: 673.315 millions/s
GPU: 0.000642+-0.000470851 s
GPU: 25.5202 millions/s
GPU [work-efficient]: 0.000257+-7.14143e-06 s
GPU [work-efficient]: 63.751 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.11667e-05+-3.72678e-07 s
CPU: 1591.97 millions/s
GPU: 0.000475333+-1.84632e-05 s
GPU: 137.874 millions/s
GPU [work-efficient]: 0.000373333+-5.73488e-06 s
GPU [work-efficient]: 175.543 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162+-0 s
CPU: 1618.17 millions/s
GPU: 0.00135483+-0.000137595 s
GPU: 193.488 millions/s
GPU [work-efficient]: 0.000752333+-1.20922e-05 s
GPU [work-efficient]: 348.441 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000660833+-2.06108e-05 s
CPU: 1586.75 millions/s
GPU: 0.00326617+-4.41075e-05 s
GPU: 321.042 millions/s
GPU [work-efficient]: 0.0016395+-7.86871e-06 s
GPU [work-efficient]: 639.571 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.002645+-1.38082e-05 s
CPU: 1585.75 millions/s
GPU: 0.012182+-9.83073e-05 s
GPU: 344.303 millions/s
GPU [work-efficient]: 0.0052245+-0.000145846 s
GPU [work-efficient]: 802.814 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0122837+-5.8784e-06 s
CPU: 1365.81 millions/s
GPU: 0.0909513+-0.00159542 s
GPU: 184.464 millions/s
GPU [work-efficient]: 0.0297518+-0.000338237 s
GPU [work-efficient]: 563.905 millions/s
</p></details>
