### PR TITLE
Task07 Petr Ivanov ITMO

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,38 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+
+__kernel void basic_prefix_sum(__global const unsigned int *as, __global unsigned int *bs, const unsigned int step, const unsigned int n)
+{
+    const unsigned int gidx = get_global_id(0);
+
+    const unsigned int left = gidx - step;
+    const unsigned int right = gidx;
+
+    if (gidx >= n)
+        return;
+
+    const unsigned int left_value = as[left];
+    const unsigned int right_value = as[right];
+
+    if (gidx >= step)
+        bs[right] = left_value + right_value;
+    else
+        bs[gidx] = right_value;
+}
+
+
+__kernel void work_efficient_prefix_sum(__global unsigned int *as, const unsigned int s, const unsigned int n, const int desc)
+{
+    const unsigned int gidx = get_global_id(0);
+
+    const unsigned int left = (desc) ? ((gidx + 1) * s * 2 - 1) : (gidx * s * 2 + s - 1);
+    const unsigned int right = left + s;
+
+    if (right < n)
+        as[right] += as[left];
+}

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -8,7 +8,7 @@
 #include "cl/prefix_sum_cl.h"
 
 
-const int benchmarkingIters = 10;
+const int benchmarkingIters = 1;
 const int benchmarkingItersCPU = 10;
 const unsigned int max_n = (1 << 24);
 
@@ -47,61 +47,83 @@ std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    ocl::Kernel basic_prefix_sum_kernel(prefix_sum_kernel, prefix_sum_kernel_length, "basic_prefix_sum");
+    ocl::Kernel work_efficient_prefix_sum_kernel(prefix_sum_kernel, prefix_sum_kernel_length, "work_efficient_prefix_sum");
+
 	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+	    std::cout << "______________________________________________" << std::endl;
+	    unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+	    std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+	    std::vector<unsigned int> as(n, 0);
+	    FastRandom r(n);
+	    for (int i = 0; i < n; ++i) {
+	        as[i] = r.next(0, values_range);
+	    }
 
-        const std::vector<unsigned int> cpu_reference = computeCPU(as);
+	    const std::vector<unsigned int> cpu_reference = computeCPU(as);
 
-// prefix sum
-#if 0
+	    gpu::gpu_mem_32u as_gpu;
+	    as_gpu.resizeN(n);
+	    gpu::gpu_mem_32u bs_gpu;
+	    bs_gpu.resizeN(n);
+
+	    {
+	        gpu::WorkSize workSize(256, n);
+	        std::vector<unsigned int> res(n);
+
+	        timer t;
+	        for (int i = 0; i < benchmarkingIters; ++i) {
+	            as_gpu.writeN(as.data(), n);
+	            t.restart();
+	            for (unsigned int step = 1; step < n; step *= 2) {
+	                basic_prefix_sum_kernel.exec(workSize, as_gpu, bs_gpu, step, n);
+	                std::swap(as_gpu, bs_gpu);
+	            }
+	            t.nextLap();
+	        }
+
+	        std::cout << "GPU [non-work-efficient]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+	        std::cout << "GPU [non-work-efficient]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+	        as_gpu.readN(res.data(), n);
+
+	        for (int i = 0; i < n; ++i) {
+	            EXPECT_THE_SAME(res[i], cpu_reference[i], "GPU results should be equal to CPU results!");
+	        }
+	    }
+
         {
             std::vector<unsigned int> res(n);
 
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
+                as_gpu.writeN(as.data(), n);
+                unsigned int last_step;
                 t.restart();
-                // TODO
-                t.nextLap();
-            }
-
-            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-
-            for (int i = 0; i < n; ++i) {
-                EXPECT_THE_SAME(cpu_reference[i], res[i], "GPU result should be consistent!");
-            }
-        }
-#endif
-
-// work-efficient prefix sum
-#if 0
-        {
-            std::vector<unsigned int> res(n);
-
-            timer t;
-            for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
-                t.restart();
-                // TODO
+                // наверное лучше workSize снаружи ограничивать, чем внутри кернела делать проверку и return
+                // (workitem'ов же явно больше, чем потоков, мб так драйвер лучше работу распределит)
+                for (unsigned int step = 1; step < n; step *= 2) {
+                    work_efficient_prefix_sum_kernel.exec(gpu::WorkSize(256, n / step / 2), as_gpu, step, n, 0);
+                    last_step = step;
+                }
+                for (unsigned int step = last_step / 2; step > 0; step /= 2) {
+                    work_efficient_prefix_sum_kernel.exec(gpu::WorkSize(256, n / step / 2), as_gpu, step, n, 1);
+                }
                 t.nextLap();
             }
 
             std::cout << "GPU [work-efficient]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU [work-efficient]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+	        as_gpu.readN(res.data(), n);
 
             for (int i = 0; i < n; ++i) {
-                EXPECT_THE_SAME(cpu_reference[i], res[i], "GPU result should be consistent!");
+                EXPECT_THE_SAME(res[i], cpu_reference[i], "GPU result should be consistent!");
             }
         }
-#endif
 	}
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
/home/peter/GPGPUTasks2024/cmake-build-debug/prefix_sum
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
Using device #0: GPU. NVIDIA GeForce RTX 3090. Total memory: 24131 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.5e-05+-0 s
CPU: 273.067 millions/s
GPU [non-work-efficient]: 0.021287+-0 s
GPU [non-work-efficient]: 0.192418 millions/s
GPU [work-efficient]: 0.000893+-0 s
GPU [work-efficient]: 4.58679 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 6e-05+-0 s
CPU: 273.067 millions/s
GPU [non-work-efficient]: 0.000103+-0 s
GPU [non-work-efficient]: 159.068 millions/s
GPU [work-efficient]: 0.000188+-0 s
GPU [work-efficient]: 87.1489 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.0002415+-5e-07 s
CPU: 271.371 millions/s
GPU [non-work-efficient]: 0.000118+-0 s
GPU [non-work-efficient]: 555.39 millions/s
GPU [work-efficient]: 0.000219+-0 s
GPU [work-efficient]: 299.251 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000994167+-2.70888e-05 s
CPU: 263.682 millions/s
GPU [non-work-efficient]: 0.000154+-0 s
GPU [non-work-efficient]: 1702.23 millions/s
GPU [work-efficient]: 0.000254+-0 s
GPU [work-efficient]: 1032.06 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00399867+-7.85486e-05 s
CPU: 262.231 millions/s
GPU [non-work-efficient]: 0.000352+-0 s
GPU [non-work-efficient]: 2978.91 millions/s
GPU [work-efficient]: 0.000419+-0 s
GPU [work-efficient]: 2502.57 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0157765+-0.000247955 s
CPU: 265.858 millions/s
GPU [non-work-efficient]: 0.001082+-0 s
GPU [non-work-efficient]: 3876.44 millions/s
GPU [work-efficient]: 0.000782+-0 s
GPU [work-efficient]: 5363.56 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0615333+-0.00117847 s
CPU: 272.652 millions/s
GPU [non-work-efficient]: 0.004248+-0 s
GPU [non-work-efficient]: 3949.44 millions/s
GPU [work-efficient]: 0.00203+-0 s
GPU [work-efficient]: 8264.64 millions/s
</pre>

</p></details>

На GPU очевидна большая зависимость скорости от размера массива для work-efficient реализации. Как будто бы это делает ее слабо применимой т.к. у нас префиксная сумма (а переполняются переменные быстро). Work-efficient реализация проигрывает обычной на массивах размером до одного миллиона

<details><summary>Вывод Github CI</summary><p>

<pre>
./prefix_sum
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 6.33333e-06+-7.45356e-07 s
CPU: 646.737 millions/s
GPU [non-work-efficient]: 0.051168+-0 s
GPU [non-work-efficient]: 0.08005 millions/s
GPU [work-efficient]: 0.042687+-0 s
GPU [work-efficient]: 0.0959543 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1e-05+-1.13687e-13 s
CPU: 1638.4 millions/s
GPU [non-work-efficient]: 0.000302+-0 s
GPU [non-work-efficient]: 54.2517 millions/s
GPU [work-efficient]: 0.000267+-0 s
GPU [work-efficient]: 61.3633 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.1e-05+-0 s
CPU: 1598.44 millions/s
GPU [non-work-efficient]: 0.000652+-0 s
GPU [non-work-efficient]: 100.515 millions/s
GPU [work-efficient]: 0.000431+-0 s
GPU [work-efficient]: 152.056 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000161+-1.81899e-12 s
CPU: 1628.22 millions/s
GPU [non-work-efficient]: 0.001636+-0 s
GPU [non-work-efficient]: 160.235 millions/s
GPU [work-efficient]: 0.000839+-0 s
GPU [work-efficient]: 312.448 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000647333+-7.45356e-07 s
CPU: 1619.84 millions/s
GPU [non-work-efficient]: 0.004389+-0 s
GPU [non-work-efficient]: 238.91 millions/s
GPU [work-efficient]: 0.002058+-0 s
GPU [work-efficient]: 509.512 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.002638+-1.04083e-05 s
CPU: 1589.96 millions/s
GPU [non-work-efficient]: 0.015217+-0 s
GPU [non-work-efficient]: 275.633 millions/s
GPU [work-efficient]: 0.006009+-0 s
GPU [work-efficient]: 698.004 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0122672+-2.81272e-05 s
CPU: 1367.65 millions/s
GPU [non-work-efficient]: 0.088291+-0 s
GPU [non-work-efficient]: 190.022 millions/s
GPU [work-efficient]: 0.029693+-0 s
GPU [work-efficient]: 565.023 millions/s
</pre>

</p></details>