### PR TITLE
Task07 Георгий Кашин ITMO

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,11 +1,16 @@
-__kernel void prefix_sum(__global unsigned int* as_gpu, unsigned int offset, unsigned int n, int down) {
+__kernel void prefix_sum(__global unsigned int* as_gpu, unsigned int offset, unsigned int n) {
     unsigned int gid = get_global_id(0);
 
     unsigned int index = gid * offset + offset - 1;
-    if (down) {
-        index -= offset / 2;
+    if (index < n) {
+        as_gpu[index] += as_gpu[index - offset / 2];
     }
+}
 
+__kernel void prefix_sum_down(__global unsigned int* as_gpu, unsigned int offset, unsigned int n) {
+    unsigned int gid = get_global_id(0);
+
+    unsigned int index = gid * offset + offset / 2 - 1;
     if (index < n) {
         as_gpu[index] += as_gpu[index - offset / 2];
     }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,15 +1,15 @@
-__kernel void upsweep(__global unsigned int* data, int shift, int n) {
-    int gid = get_global_id(0);
-    int index = shift * (gid + 1) - 1;
+__kernel void upsweep(__global unsigned int* data, unsigned int shift, unsigned int n) {
+    unsigned int gid = get_global_id(0);
+    unsigned int index = shift * (gid + 1) - 1;
 
     if (index < n) {
         data[index] += data[index - shift / 2];
     }
 }
 
-__kernel void downsweep(__global unsigned int* data, int shift, int n) {
-    int gid = get_global_id(0);
-    int index = shift * (gid + 1) - 1;
+__kernel void downsweep(__global unsigned int* data, unsigned int shift, unsigned int n) {
+    unsigned int gid = get_global_id(0);
+    unsigned int index = shift * (gid + 1) - 1;
 
     if (index < n) {
         unsigned int temp = data[index - shift / 2];

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,5 +1,5 @@
 __kernel void upsweep(__global unsigned int* data, unsigned int shift, unsigned int n) {
-    unsigned int gid = get_global_id(0);
+    int gid = get_global_id(0);
     unsigned int index = shift * (gid + 1) - 1;
 
     if (index < n) {
@@ -8,7 +8,7 @@ __kernel void upsweep(__global unsigned int* data, unsigned int shift, unsigned 
 }
 
 __kernel void downsweep(__global unsigned int* data, unsigned int shift, unsigned int n) {
-    unsigned int gid = get_global_id(0);
+    int gid = get_global_id(0);
     unsigned int index = shift * (gid + 1) - 1;
 
     if (index < n) {

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,12 @@
-// TODO
+__kernel void prefix_sum(__global unsigned int* as_gpu, unsigned int offset, unsigned int n, int down) {
+    unsigned int gid = get_global_id(0);
+
+    unsigned int index = gid * offset + offset - 1;
+    if (down) {
+        index -= offset / 2;
+    }
+
+    if (index < n) {
+        as_gpu[index] += as_gpu[index - offset / 2];
+    }
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,17 +1,25 @@
-__kernel void prefix_sum(__global unsigned int* as_gpu, unsigned int offset, unsigned int n) {
-    unsigned int gid = get_global_id(0);
+__kernel void upsweep(__global unsigned int* data, int shift, int n) {
+    int gid = get_global_id(0);
+    int index = shift * (gid + 1) - 1;
 
-    unsigned int index = gid * offset + offset - 1;
     if (index < n) {
-        as_gpu[index] += as_gpu[index - offset / 2];
+        data[index] += data[index - shift / 2];
     }
 }
 
-__kernel void prefix_sum_down(__global unsigned int* as_gpu, unsigned int offset, unsigned int n) {
-    unsigned int gid = get_global_id(0);
+__kernel void downsweep(__global unsigned int* data, int shift, int n) {
+    int gid = get_global_id(0);
+    int index = shift * (gid + 1) - 1;
 
-    unsigned int index = gid * offset + offset / 2 - 1;
     if (index < n) {
-        as_gpu[index] += as_gpu[index - offset / 2];
+        unsigned int temp = data[index - shift / 2];
+        data[index - shift / 2] = data[index];
+        data[index] += temp;
+    }
+}
+
+__kernel void set_zero(__global unsigned int* data, unsigned int n) {
+    if (get_global_id(0) == 0) {
+        data[n - 1] = 0;
     }
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -85,7 +85,6 @@ int main(int argc, char **argv)
                     prefix_sum.exec(gpu::WorkSize(128, n >> offset), as_gpu, 1 << offset, n, 1);
                 }
 
-
                 t.nextLap();
             }
             as_gpu.readN(res.data(), n);

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -82,18 +82,18 @@ int main(int argc, char **argv)
                 as_gpu.writeN(as.data(), n);
                 t.restart();
 
-                int logn = (int)ceil(log2(n));
-                for (int i = 0; i < logn; i++) {
-                    int shift = 1 << (i + 1);
-                    int global_size = (n - 1) / shift + 1;
+                unsigned int logn = (int)ceil(log2(n));
+                for (unsigned int i = 0; i < logn; i++) {
+                    unsigned int shift = 1 << (i + 1);
+                    unsigned int global_size = (n - 1) / shift + 1;
                     upsweep.exec(gpu::WorkSize(local_size, global_size), as_gpu, shift, n);
                 }
 
                 set_zero.exec(gpu::WorkSize(1, 1), as_gpu, n);
 
-                for (int i = logn - 1; i >= 0; i--) {
-                    int shift = 1 << (i + 1);
-                    int global_size = (n - 1) / shift + 1;
+                for (unsigned int i = logn - 1; i >= 0; i--) {
+                    unsigned int shift = 1 << (i + 1);
+                    unsigned int global_size = (n - 1) / shift + 1;
                     downsweep.exec(gpu::WorkSize(local_size, global_size), as_gpu, shift, n);
 
                 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -83,6 +83,7 @@ int main(int argc, char **argv)
                     prefix_sum.exec(gpu::WorkSize(128, n >> offset), as_gpu, 1 << offset, n);
                 }
 
+
                 for (int offset = log2(n); offset > 0; offset--) {
                     prefix_sum_down.exec(gpu::WorkSize(128, n >> offset), as_gpu, 1 << offset, n);
                 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -95,6 +95,7 @@ int main(int argc, char **argv)
                     int shift = 1 << (i + 1);
                     int global_size = (n - 1) / shift + 1;
                     downsweep.exec(gpu::WorkSize(local_size, global_size), as_gpu, shift, n);
+
                 }
                 t.nextLap();
             }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -87,7 +87,6 @@ int main(int argc, char **argv)
 #endif
 
 // work-efficient prefix sum
-#if 1
         {
             std::vector<unsigned int> res(n);
             gpu::gpu_mem_32u as_gpu;
@@ -120,6 +119,5 @@ int main(int argc, char **argv)
                 EXPECT_THE_SAME(cpu_reference[i], res[i], "GPU result should be consistent!");
             }
         }
-#endif
 	}
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
                 t.restart();
 
                 unsigned int logn = (int)ceil(log2(n));
-                for (unsigned int i = 0; i < logn; i++) {
+                for (int i = 0; i < logn; i++) {
                     unsigned int shift = 1 << (i + 1);
                     unsigned int global_size = (n - 1) / shift + 1;
                     upsweep.exec(gpu::WorkSize(local_size, global_size), as_gpu, shift, n);
@@ -91,11 +91,10 @@ int main(int argc, char **argv)
 
                 set_zero.exec(gpu::WorkSize(1, 1), as_gpu, n);
 
-                for (unsigned int i = logn - 1; i >= 0; i--) {
+                for (int i = logn - 1; i >= 0; i--) {
                     unsigned int shift = 1 << (i + 1);
                     unsigned int global_size = (n - 1) / shift + 1;
                     downsweep.exec(gpu::WorkSize(local_size, global_size), as_gpu, shift, n);
-
                 }
                 t.nextLap();
             }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -64,28 +64,6 @@ int main(int argc, char **argv)
 
         const std::vector<unsigned int> cpu_reference = computeCPU(as);
 
-// prefix sum
-#if 0
-        {
-            std::vector<unsigned int> res(n);
-
-            timer t;
-            for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
-                t.restart();
-                // TODO
-                t.nextLap();
-            }
-
-            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-
-            for (int i = 0; i < n; ++i) {
-                EXPECT_THE_SAME(cpu_reference[i], res[i], "GPU result should be consistent!");
-            }
-        }
-#endif
-
 // work-efficient prefix sum
         {
             std::vector<unsigned int> res(n);

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -108,6 +108,7 @@ int main(int argc, char **argv)
                     prefix_sum.exec(gpu::WorkSize(128, n >> offset), as_gpu, 1 << offset, n, 1);
                 }
 
+
                 t.nextLap();
             }
             as_gpu.readN(res.data(), n);


### PR DESCRIPTION
Local machine:

```
OpenCL devices:
  Device #0: GPU. Apple M1. Total memory: 10922 Mb
Using device #0: GPU. Apple M1. Total memory: 10922 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.9e-05+-0 s
CPU: 141.241 millions/s
GPU [work-efficient]: 0.0083865+-0.000882419 s
GPU [work-efficient]: 0.488404 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 7.88333e-05+-6.93822e-06 s
CPU: 207.831 millions/s
GPU [work-efficient]: 0.010776+-0.000874803 s
GPU [work-efficient]: 1.52042 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.00032+-1.30128e-05 s
CPU: 204.8 millions/s
GPU [work-efficient]: 0.0107442+-0.000708353 s
GPU [work-efficient]: 6.09968 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00126017+-4.06916e-05 s
CPU: 208.023 millions/s
GPU [work-efficient]: 0.009446+-0.0014123 s
GPU [work-efficient]: 27.7519 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00475467+-4.57044e-06 s
CPU: 220.536 millions/s
GPU [work-efficient]: 0.0109637+-0.00140791 s
GPU [work-efficient]: 95.641 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0189005+-9.9235e-05 s
CPU: 221.915 millions/s
GPU [work-efficient]: 0.0198872+-0.00165214 s
GPU [work-efficient]: 210.905 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.075439+-0.000344761 s
CPU: 222.394 millions/s
GPU [work-efficient]: 0.0414497+-0.00132142 s
GPU [work-efficient]: 404.761 millions/s
```

CI:
```
n=4096 values in range: [0; 1023]
CPU: 6.16667e-06+-6.87184e-07 s
CPU: 664.216 millions/s
GPU [work-efficient]: 0.000203833+-5.36708e-06 s
GPU [work-efficient]: 20.0948 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.06667e-05+-1.49071e-06 s
CPU: 1536 millions/s
GPU [work-efficient]: 0.000262167+-4.25898e-06 s
GPU [work-efficient]: 62.4946 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.5e-05+-0 s
CPU: 1456.36 millions/s
GPU [work-efficient]: 0.000383667+-6.69992e-06 s
GPU [work-efficient]: 170.815 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162+-0 s
CPU: 1618.17 millions/s
GPU [work-efficient]: 0.000716+-8.12404e-06 s
GPU [work-efficient]: 366.123 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000647667+-4.71405e-07 s
CPU: 1619.01 millions/s
GPU [work-efficient]: 0.00174183+-1.18521e-05 s
GPU [work-efficient]: 601.996 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00263917+-1.76108e-05 s
CPU: 1589.25 millions/s
GPU [work-efficient]: 0.00467833+-0.000108944 s
GPU [work-efficient]: 896.538 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0408703+-0.000182092 s
CPU: 410.499 millions/s
GPU [work-efficient]: 0.028987+-0.000504707 s
GPU [work-efficient]: 578.784 millions/s
```