### PR TITLE
Task07 Андрей Гладких ITMO

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,35 @@
-// TODO
+#define WORKGROUP_SIZE (128)
+
+__kernel void prefix_sum(__global unsigned int* as, __global unsigned int* bs, const unsigned int n, const unsigned int step) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid + step >= n) {
+        return;
+    }
+
+    if (gid < step) {
+        bs[gid] = as[gid];
+    }
+
+    bs[gid + step] = as[gid] + as[gid + step];
+}
+
+__kernel void prefix_sum_work_efficient_up(__global unsigned int* as, const unsigned int step, const unsigned int workSize) {
+    const uint gid = get_global_id(0);
+
+    if (gid >= workSize) {
+        return;
+    }
+
+    as[step * (gid * 2 + 2) - 1] += as[step * (gid * 2 + 1) - 1];
+}
+
+__kernel void prefix_sum_work_efficient_down(__global unsigned int* as, const unsigned int step, const unsigned int workSize) {
+    const uint gid = get_global_id(0);
+
+    if (gid >= workSize) {
+        return;
+    }
+    
+    as[step * (gid + 1) + step / 2 - 1] += as[step * (gid + 1) - 1];
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,5 +1,3 @@
-#define WORKGROUP_SIZE (128)
-
 __kernel void prefix_sum(__global unsigned int* as, __global unsigned int* bs, const unsigned int n, const unsigned int step) {
     const unsigned int gid = get_global_id(0);
 

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -24,10 +24,14 @@ __kernel void prefix_sum_work_efficient_up(__global unsigned int* as, const unsi
     as[step * (gid * 2 + 2) - 1] += as[step * (gid * 2 + 1) - 1];
 }
 
-__kernel void prefix_sum_work_efficient_down(__global unsigned int* as, const unsigned int step, const unsigned int workSize) {
+__kernel void prefix_sum_work_efficient_down(__global unsigned int* as, const unsigned int n, const unsigned int step, const unsigned int workSize) {
     const uint gid = get_global_id(0);
 
     if (gid >= workSize) {
+        return;
+    }
+
+    if (step * (gid + 1) + step / 2 - 1 >= n) {
         return;
     }
     

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
 
                 unsigned int step = 1;
                 for (; step < n; step *= 2) {
-                    const unsigned int workSize = n / step;
+                    const unsigned int workSize = n / (step * 2);
                     prefix_sum_work_efficient_up.exec(gpu::WorkSize(256, workSize), as_gpu, step, workSize);
                 }
 

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 
                 for (step /= 2; step > 1; step /= 2) {
                     const unsigned int workSize = n / step;
-                    prefix_sum_work_efficient_down.exec(gpu::WorkSize(256, workSize), as_gpu, step, workSize);
+                    prefix_sum_work_efficient_down.exec(gpu::WorkSize(256, workSize), as_gpu, n, step, workSize);
                 }
 
                 t.nextLap();


### PR DESCRIPTION
<details><summary>Локальный вывод GPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800X 8-Core Processor             . Intel(R) Corporation. Total memory: 32670 Mb
  Device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Using device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 4.06667e-05+-3.68179e-06 s
CPU: 100.721 millions/s
GPU: 0.000338167+-2.01281e-05 s
GPU: 12.1124 millions/s
GPU [work-efficient]: 0.000838333+-0.000158643 s
GPU [work-efficient]: 4.88588 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000138167+-1.34371e-06 s
CPU: 118.581 millions/s
GPU: 0.000435833+-5.76004e-05 s
GPU: 37.5924 millions/s
GPU [work-efficient]: 0.0007405+-1.72216e-05 s
GPU [work-efficient]: 22.1256 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.0005745+-1.58193e-05 s
CPU: 114.075 millions/s
GPU: 0.000434333+-1.07186e-05 s
GPU: 150.889 millions/s
GPU [work-efficient]: 0.000901333+-6.86019e-05 s
GPU [work-efficient]: 72.7101 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0027425+-0.000378107 s
CPU: 95.5858 millions/s
GPU: 0.000551167+-9.86296e-05 s
GPU: 475.617 millions/s
GPU [work-efficient]: 0.000896833+-1.02862e-05 s
GPU [work-efficient]: 292.3 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00871417+-2.32767e-05 s
CPU: 120.33 millions/s
GPU: 0.000581667+-1.3136e-05 s
GPU: 1802.71 millions/s
GPU [work-efficient]: 0.001033+-4.86484e-06 s
GPU [work-efficient]: 1015.08 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0345633+-6.79918e-05 s
CPU: 121.351 millions/s
GPU: 0.000716333+-3.5231e-05 s
GPU: 5855.24 millions/s
GPU [work-efficient]: 0.00143417+-1.10366e-05 s
GPU [work-efficient]: 2924.56 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.139694+-0.000136748 s
CPU: 120.1 millions/s
GPU: 0.0058045+-0.000123757 s
GPU: 2890.38 millions/s
GPU [work-efficient]: 0.00377283+-9.01543e-05 s
GPU [work-efficient]: 4446.85 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод CPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800X 8-Core Processor             . Intel(R) Corporation. Total memory: 32670 Mb
  Device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Using device #0: CPU. AMD Ryzen 7 5800X 8-Core Processor             . Intel(R) Corporation. Total memory: 32670 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 3.4e-05+-0 s
CPU: 120.471 millions/s
GPU: 0.000241+-5.88784e-06 s
GPU: 16.9959 millions/s
GPU [work-efficient]: 0.000354833+-4.17998e-06 s
GPU [work-efficient]: 11.5434 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000154833+-1.65873e-05 s
CPU: 105.817 millions/s
GPU: 0.000349833+-1.56994e-05 s
GPU: 46.8337 millions/s
GPU [work-efficient]: 0.000545333+-3.53443e-05 s
GPU [work-efficient]: 30.044 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.0005525+-9.57427e-07 s
CPU: 118.617 millions/s
GPU: 0.000662333+-7.49237e-05 s
GPU: 98.9472 millions/s
GPU [work-efficient]: 0.000647+-4.93525e-05 s
GPU [work-efficient]: 101.292 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.002246+-7.63763e-06 s
CPU: 116.716 millions/s
GPU: 0.00116817+-7.29027e-05 s
GPU: 224.406 millions/s
GPU [work-efficient]: 0.0006925+-2.57795e-05 s
GPU [work-efficient]: 378.547 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0087275+-3.9263e-05 s
CPU: 120.146 millions/s
GPU: 0.00430033+-0.000187292 s
GPU: 243.836 millions/s
GPU [work-efficient]: 0.00109267+-6.34184e-05 s
GPU [work-efficient]: 959.649 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.034482+-8.69272e-05 s
CPU: 121.637 millions/s
GPU: 0.0109372+-0.000638046 s
GPU: 383.491 millions/s
GPU [work-efficient]: 0.0027+-0.000152687 s
GPU [work-efficient]: 1553.45 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.138948+-0.000311441 s
CPU: 120.744 millions/s
GPU: 0.140939+-0.00158545 s
GPU: 119.039 millions/s
GPU [work-efficient]: 0.0337843+-0.00104997 s
GPU [work-efficient]: 496.598 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 6e-06+-0 s
CPU: 682.667 millions/s
GPU: 0.0001335+-2.29129e-06 s
GPU: 30.6816 millions/s
GPU [work-efficient]: 0.000174833+-1.21335e-06 s
GPU [work-efficient]: 23.428 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.26667e-05+-5.52771e-06 s
CPU: 1293.47 millions/s
GPU: 0.000204333+-4.42217e-06 s
GPU: 80.1827 millions/s
GPU [work-efficient]: 0.00023+-1.52753e-06 s
GPU [work-efficient]: 71.2348 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4e-05+-4.54747e-13 s
CPU: 1638.4 millions/s
GPU: 0.000403167+-5.01387e-06 s
GPU: 162.553 millions/s
GPU [work-efficient]: 0.000335333+-6.39444e-06 s
GPU [work-efficient]: 195.435 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162+-0 s
CPU: 1618.17 millions/s
GPU: 0.001127+-7.02401e-05 s
GPU: 232.603 millions/s
GPU [work-efficient]: 0.000678667+-2.35632e-05 s
GPU [work-efficient]: 386.263 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000649667+-1.69967e-06 s
CPU: 1614.02 millions/s
GPU: 0.0024455+-8.56052e-05 s
GPU: 428.778 millions/s
GPU [work-efficient]: 0.00159083+-5.76206e-05 s
GPU [work-efficient]: 659.136 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00263283+-5.36708e-06 s
CPU: 1593.08 millions/s
GPU: 0.00867017+-0.000179559 s
GPU: 483.763 millions/s
GPU [work-efficient]: 0.0040925+-6.95216e-05 s
GPU [work-efficient]: 1024.88 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.012298+-1.19304e-05 s
CPU: 1364.22 millions/s
GPU: 0.0824883+-0.000736337 s
GPU: 203.389 millions/s
GPU [work-efficient]: 0.0258302+-0.000114044 s
GPU [work-efficient]: 649.52 millions/s
</pre>

</p></details>

В общем случае work-efficient реализация с увеличением размера массива начинает работать быстрее, чем наивная. Что интересно - локально на GPU у меня выигрыш получился только на последнем размере массива, а вот на CPU work-efficient версия быстрее начиная с длины массива 65536. На CI результаты схожие с моими на CPU.