### PR TITLE
Task07 Виноградов Александр HSE

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,41 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void prefix_sum(__global const unsigned int* array, __global unsigned int* prefix_sum, unsigned int offset)
+{
+    int gid = get_global_id(0);
+
+    if (gid < offset) {
+        prefix_sum[gid] = array[gid];
+        return;
+    }
+
+    prefix_sum[gid] = array[gid - offset] + array[gid];
+}
+
+__kernel void prefix_sum_work_eff_down(__global unsigned int* prefix_sum, unsigned int n, unsigned int power)
+{
+    int gid = get_global_id(0);
+
+    int idx = 2 * (gid + 1) * power - 1;
+    if (idx < 0 || idx >= n) {
+        return;
+    }
+
+    prefix_sum[idx] += prefix_sum[idx - power];
+}
+
+__kernel void prefix_sum_work_eff_up(__global unsigned int* prefix_sum, unsigned int n, unsigned int power)
+{
+    int gid = get_global_id(0);
+    int idx = power + 2 * (gid + 1) * power - 1;
+
+    if (idx < 0 || idx >= n) {
+        return;
+    }
+
+    prefix_sum[idx] += prefix_sum[idx - power];
+}


### PR DESCRIPTION
<details><summary>Локальный вывод prefix sum</summary><p>

<pre>
$ ./prefixSum

OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz. Intel(R) Corporation. Total memory: 32573 Mb
  Device #1: GPU. Intel(R) UHD Graphics 750. Total memory: 13029 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.83333e-05+-1.69967e-06 s
CPU: 223.418 millions/s
GPU: 0.000326667+-3.36436e-05 s
GPU: 12.5388 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 7.41667e-05+-1.06719e-06 s
CPU: 220.908 millions/s
GPU: 0.000356167+-2.71011e-05 s
GPU: 46.0009 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000296667+-7.03957e-06 s
CPU: 220.908 millions/s
GPU: 0.000377667+-1.63978e-05 s
GPU: 173.529 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00123917+-3.73203e-05 s
CPU: 211.549 millions/s
GPU: 0.0004765+-1.15289e-05 s
GPU: 550.145 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0050725+-3.23252e-05 s
CPU: 206.718 millions/s
GPU: 0.0008295+-2.11877e-05 s
GPU: 1264.11 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0206493+-0.000447352 s
CPU: 203.121 millions/s
GPU: 0.00247367+-5.4753e-05 s
GPU: 1695.58 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0845133+-0.000872536 s
CPU: 198.516 millions/s
GPU: 0.00954683+-3.03667e-05 s
GPU: 1757.36 millions/s

</p></details>

<details><summary>Локальный вывод prefix sum work-efficient</summary><p>

<pre>
$ ./prefixSum
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz. Intel(R) Corporation. Total memory: 32573 Mb
  Device #1: GPU. Intel(R) UHD Graphics 750. Total memory: 13029 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3070. Total memory: 8191 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.63333e-05+-7.45356e-07 s
CPU: 250.776 millions/s
GPU [work-efficient]: 0.000593333+-1.11903e-05 s
GPU [work-efficient]: 6.90337 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 8.08333e-05+-1.06719e-06 s
CPU: 202.689 millions/s
GPU [work-efficient]: 0.000666167+-2.13964e-05 s
GPU [work-efficient]: 24.5944 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000392167+-7.44797e-06 s
CPU: 167.113 millions/s
GPU [work-efficient]: 0.000751667+-1.62447e-05 s
GPU [work-efficient]: 87.1876 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00130767+-4.65212e-05 s
CPU: 200.467 millions/s
GPU [work-efficient]: 0.000852+-4.94132e-05 s
GPU [work-efficient]: 307.681 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00534383+-0.000105338 s
CPU: 196.222 millions/s
GPU [work-efficient]: 0.000911667+-1.86428e-05 s
GPU [work-efficient]: 1150.17 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0214985+-0.00028095 s
CPU: 195.098 millions/s
GPU [work-efficient]: 0.00163417+-3.70784e-05 s
GPU [work-efficient]: 2566.63 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0826822+-0.000859481 s
CPU: 202.912 millions/s
GPU [work-efficient]: 0.00444867+-0.000106509 s
GPU [work-efficient]: 3771.29 millions/s

Process finished with exit code 0

</pre>

</p></details>

Видно, что 2 реализация при большом `n` на GPU эффективнее более, чем в 2 раза