### PR TITLE
Task07 Роман Гостило HSE

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,31 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#line 6
+__kernel void prefix_stage1(__global unsigned int *as, unsigned int step, unsigned int n) {
+    int global_id = get_global_id(0);
+
+    int arr_id = (global_id + 1) * (1 << step) - 1;
+
+    if (arr_id >= n)
+        return;
+
+    as[arr_id] += as[arr_id - (1 << (step - 1))];
+}
+
+#line 6
+__kernel void prefix_stage2(__global unsigned int *as, unsigned int step, unsigned int n) {
+    int global_id = get_global_id(0);
+
+    int cur_block = (1 << step);
+
+    int arr_id = (global_id + 1) * (1 << step) - 1;
+
+    if (arr_id + cur_block / 2 >= n)
+        return;
+
+    as[arr_id + cur_block / 2] += as[arr_id];
+}


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
<pre>
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.26667e-05+-7.45356e-07 s
CPU: 180.706 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU [work-efficient]: 0.00206583+-7.40955e-05 s
GPU [work-efficient]: 1.98273 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 8.85e-05+-5e-07 s
CPU: 185.13 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU [work-efficient]: 0.00235667+-3.86767e-05 s
GPU [work-efficient]: 6.95219 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000354833+-8.97527e-07 s
CPU: 184.695 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU [work-efficient]: 0.00278017+-4.49534e-05 s
GPU [work-efficient]: 23.5727 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.001459+-3.21455e-06 s
CPU: 179.674 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU [work-efficient]: 0.00327017+-7.16134e-05 s
GPU [work-efficient]: 80.1623 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00591317+-2.33981e-05 s
CPU: 177.329 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU [work-efficient]: 0.00394533+-0.000149692 s
GPU [work-efficient]: 265.776 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0234798+-6.45921e-05 s
CPU: 178.634 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU [work-efficient]: 0.00522367+-0.000137069 s
GPU [work-efficient]: 802.943 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0936823+-8.46968e-05 s
CPU: 179.086 millions/s
OpenCL devices:
  Device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
Using device #0: GPU. Apple M3 Max. Total memory: 27648 Mb
GPU [work-efficient]: 0.00665117+-0.000124702 s
GPU [work-efficient]: 2522.45 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 3.83333e-06+-3.72678e-07 s
CPU: 1068.52 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU [work-efficient]: 9.43333e-05+-1.97203e-06 s
GPU [work-efficient]: 43.4205 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.61667e-05+-2.85287e-06 s
CPU: 1013.44 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU [work-efficient]: 0.000128333+-1.69967e-06 s
GPU [work-efficient]: 127.668 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4e-05+-4.54747e-13 s
CPU: 1638.4 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU [work-efficient]: 0.000188667+-3.39935e-06 s
GPU [work-efficient]: 347.364 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162667+-1.97203e-06 s
CPU: 1611.54 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU [work-efficient]: 0.000366+-9.71253e-06 s
GPU [work-efficient]: 716.24 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000651333+-4.34613e-06 s
CPU: 1609.89 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU [work-efficient]: 0.000914667+-4.35265e-05 s
GPU [work-efficient]: 1146.4 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00263583+-5.2731e-06 s
CPU: 1591.26 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU [work-efficient]: 0.00247667+-4.47574e-05 s
GPU [work-efficient]: 1693.53 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0154778+-1.70041e-05 s
CPU: 1083.95 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU [work-efficient]: 0.0152612+-0.000317501 s
GPU [work-efficient]: 1099.34 millions/s

</pre>

</p></details>

В CI реализация на GPU почти не обгоняет реализацию на CPU, но вот локально разница кратная. Связано, вероятно, с тем, что на Apple Silicon есть отдельное видеоядро и потоков где-то как на GTX1080, а в CI видеоядра нет