### PR TITLE
Task07 Артем Сидоренко HSE

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -7,12 +7,12 @@
 #line 7
 
 __kernel void pref_sum_naive(__global unsigned int *prev, __global unsigned int *next, int offset, int n) {
-    int gid = get_global_id(0);
+    int ind = get_global_id(0);
 
-    int ind_to_add = gid + offset;
-    if (ind_to_add >= n) return;
+    next[ind] = prev[ind];
 
-    next[ind_to_add] += prev[gid];
+    int ind_to_add = ind - offset;
+    if (ind_to_add >= 0) next[ind] += prev[ind_to_add];
 }
 
 __kernel void pref_sum_efficient(__global unsigned int *ps, int offset, int n, int part) {

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,31 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include "clion_defines.cl"
+
+#endif
+
+#line 7
+
+__kernel void pref_sum_naive(__global unsigned int *prev, __global unsigned int *next, int offset, int n) {
+    int gid = get_global_id(0);
+
+    int ind_to_add = gid + offset;
+    if (ind_to_add >= n) return;
+
+    next[ind_to_add] += prev[gid];
+}
+
+__kernel void pref_sum_efficient(__global unsigned int *ps, int offset, int n, int part) {
+    int gid = get_global_id(0);
+
+    int ind = part == 0 ?
+              (gid + 1) * (offset << 1) - 1 - offset : // first part of algo
+              (gid + 1) * (offset << 1) - 1; // second part of algo
+
+    int ind_to_add = ind + offset;
+    if (ind_to_add >= n) return;
+
+//    printf("Indices are: ind=%d, ind_to_add=%d\n", ind, ind_to_add);
+
+    ps[ind_to_add] += ps[ind];
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -9,6 +9,8 @@
 __kernel void pref_sum_naive(__global unsigned int *prev, __global unsigned int *next, int offset, int n) {
     int ind = get_global_id(0);
 
+    if (ind >= n) return;
+
     next[ind] = prev[ind];
 
     int ind_to_add = ind - offset;

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -81,9 +81,10 @@ int main(int argc, char **argv)
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
                 res_gpu.writeN(as.data(), n);
+                res_gpu_prev.writeN(as.data(), n);
                 t.restart();
                 for (unsigned offset = 1; offset < n; offset <<= 1) {
-                    res_gpu.copyToN(res_gpu_prev, n);
+                    res_gpu.swap(res_gpu_prev);
                     pref_sum_naive.exec(ws, res_gpu_prev, res_gpu, offset, n);
                 }
                 t.nextLap();

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -47,7 +47,12 @@ std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
 
 int main(int argc, char **argv)
 {
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+	for (unsigned int n = 4; n <= max_n; n *= 4) {
 		std::cout << "______________________________________________" << std::endl;
 		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
 		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
@@ -61,17 +66,30 @@ int main(int argc, char **argv)
         const std::vector<unsigned int> cpu_reference = computeCPU(as);
 
 // prefix sum
-#if 0
+#if 1
         {
             std::vector<unsigned int> res(n);
 
+            gpu::gpu_mem_32u res_gpu, res_gpu_prev;
+            res_gpu.resizeN(n);
+            res_gpu_prev.resizeN(n);
+
+            ocl::Kernel pref_sum_naive(prefix_sum_kernel, prefix_sum_kernel_length, "pref_sum_naive");
+            pref_sum_naive.compile();
+            gpu::WorkSize ws(128, n);
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
+                res_gpu.writeN(as.data(), n);
                 t.restart();
-                // TODO
+                for (unsigned offset = 1; offset < n; offset <<= 1) {
+                    res_gpu.copyToN(res_gpu_prev, n);
+                    pref_sum_naive.exec(ws, res_gpu_prev, res_gpu, offset, n);
+                }
                 t.nextLap();
             }
+
+            res_gpu.readN(res.data(), n);
 
             std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
@@ -83,24 +101,43 @@ int main(int argc, char **argv)
 #endif
 
 // work-efficient prefix sum
-#if 0
+#if 1
         {
             std::vector<unsigned int> res(n);
 
+            gpu::gpu_mem_32u res_gpu;
+            res_gpu.resizeN(n);
+
+            ocl::Kernel pref_sum_efficient(prefix_sum_kernel, prefix_sum_kernel_length, "pref_sum_efficient");
+            pref_sum_efficient.compile();
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
+                res_gpu.writeN(as.data(), n);
                 t.restart();
-                // TODO
+                for (unsigned offset = 1; offset < n; offset <<= 1) {
+//                    std::cout << "Offset: " << offset << std::endl;
+                    gpu::WorkSize ws(128, n / (offset << 1));
+                    pref_sum_efficient.exec(ws, res_gpu, offset, n, 0);
+                }
+
+                for (unsigned offset = n >> 2; offset > 0; offset >>= 1) {
+                    gpu::WorkSize ws(128, n / (offset << 1));
+                    pref_sum_efficient.exec(ws, res_gpu, offset, n, 1);
+                }
                 t.nextLap();
             }
 
             std::cout << "GPU [work-efficient]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU [work-efficient]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
 
+            res_gpu.readN(res.data(), n);
+
             for (int i = 0; i < n; ++i) {
+//                std::cout << res[i] << " ";
                 EXPECT_THE_SAME(cpu_reference[i], res[i], "GPU result should be consistent!");
             }
+//            std::cout << std::endl;
         }
 #endif
 	}


### PR DESCRIPTION
```
C:\Users\79189\CLionProjects\GPGPUTasks2024\cmake-build-debug\prefix_sum.exe 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 4800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15791 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6161/6241 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 5.88333e-05+-1.58789e-05 s
GPU: 0.0679887 millions/s
GPU [work-efficient]: 8.68333e-05+-8.31498e-06 s
GPU [work-efficient]: 0.0460653 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000106833+-6.14862e-06 s
GPU: 0.149766 millions/s
GPU [work-efficient]: 0.000173667+-1.0274e-05 s
GPU [work-efficient]: 0.0921305 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000159667+-4.88763e-06 s
GPU: 0.400835 millions/s
GPU [work-efficient]: 0.000293833+-2.24308e-05 s
GPU [work-efficient]: 0.217811 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 1e-06+-0 s
CPU: 256 millions/s
GPU: 0.0002065+-3.5e-06 s
GPU: 1.23971 millions/s
GPU [work-efficient]: 0.000373833+-3.43592e-06 s
GPU [work-efficient]: 0.684797 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 5e-06+-5.68434e-14 s
CPU: 204.8 millions/s
GPU: 0.000242+-1.47535e-05 s
GPU: 4.2314 millions/s
GPU [work-efficient]: 0.000463167+-1.23749e-05 s
GPU [work-efficient]: 2.21087 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2e-05+-2.27374e-13 s
CPU: 204.8 millions/s
GPU: 0.000300167+-6.46572e-06 s
GPU: 13.6458 millions/s
GPU [work-efficient]: 0.000576+-2.58908e-05 s
GPU [work-efficient]: 7.11111 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 8.2e-05+-0 s
CPU: 199.805 millions/s
GPU: 0.000362333+-1.30597e-05 s
GPU: 45.218 millions/s
GPU [work-efficient]: 0.0006685+-2.24555e-05 s
GPU [work-efficient]: 24.5086 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000331667+-1.69967e-06 s
CPU: 197.596 millions/s
GPU: 0.000430333+-1.67995e-05 s
GPU: 152.291 millions/s
GPU [work-efficient]: 0.000786+-2.2286e-05 s
GPU [work-efficient]: 83.3791 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.001327+-1.1547e-06 s
CPU: 197.546 millions/s
GPU: 0.000531167+-7.86165e-06 s
GPU: 493.525 millions/s
GPU [work-efficient]: 0.000901+-5.56776e-06 s
GPU [work-efficient]: 290.948 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00548433+-0.000341857 s
CPU: 191.195 millions/s
GPU: 0.000923+-2.30362e-05 s
GPU: 1136.05 millions/s
GPU [work-efficient]: 0.0011455+-1.46941e-05 s
GPU [work-efficient]: 915.387 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0219693+-0.000209667 s
CPU: 190.916 millions/s
GPU: 0.00288167+-1.0274e-05 s
GPU: 1455.51 millions/s
GPU [work-efficient]: 0.00197017+-1.64562e-05 s
GPU [work-efficient]: 2128.91 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0928867+-0.0050576 s
CPU: 180.62 millions/s
GPU: 0.0115542+-3.88476e-05 s
GPU: 1452.05 millions/s
GPU [work-efficient]: 0.00529867+-0.000113067 s
GPU [work-efficient]: 3166.31 millions/s

Process finished with exit code 0
```