### PR TITLE
Task07 Даниил Русов ITMO

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,18 @@
-// TODO
+__kernel void prefix_sum_efficient_first(__global unsigned int* as, unsigned int n, unsigned int step)
+{
+	unsigned int idx = get_global_id(0);
+	unsigned int second = (idx + 1) * step * 2 - 1;
+	unsigned int first = second - step;
+	if (second < n)
+		as[second] = as[first] + as[second];
+}
+
+
+__kernel void prefix_sum_efficient_second(__global unsigned int* as, unsigned int n, unsigned int step)
+{
+	unsigned int idx = get_global_id(0);
+	unsigned int second = (idx + 1) * step * 2 - 1 + step;
+	unsigned int first = second - step;
+	if (second < n)
+		as[second] = as[first] + as[second];
+}


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16011 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6404 Mb
  Device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
Using device #2: GPU. NVIDIA GeForce RTX 4060 Laptop GPU. Total memory: 8187 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 3.05e-05+-1.60728e-06 s
CPU: 134.295 millions/s
GPU [work-efficient]: 0.00108667+-7.01728e-05 s
GPU [work-efficient]: 3.76933 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000135833+-7.05731e-06 s
CPU: 120.618 millions/s
GPU [work-efficient]: 0.000697833+-6.18746e-05 s
GPU [work-efficient]: 23.4784 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000504+-3.54589e-05 s
CPU: 130.032 millions/s
GPU [work-efficient]: 0.0009465+-3.28621e-05 s
GPU [work-efficient]: 69.2404 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0025005+-0.000377969 s
CPU: 104.837 millions/s
GPU [work-efficient]: 0.0008375+-2.31427e-05 s
GPU [work-efficient]: 313.008 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00844433+-0.000182134 s
CPU: 124.175 millions/s
GPU [work-efficient]: 0.00200083+-0.000315185 s
GPU [work-efficient]: 524.07 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0305693+-0.000492695 s
CPU: 137.206 millions/s
GPU [work-efficient]: 0.00134733+-0.000161225 s
GPU [work-efficient]: 3113.04 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.118503+-0.000471136 s
CPU: 141.576 millions/s
GPU [work-efficient]: 0.00630133+-9.719e-05 s
GPU [work-efficient]: 2662.49 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 5e-06+-8.16497e-07 s
CPU: 819.2 millions/s
GPU [work-efficient]: 0.000184667+-1.02902e-05 s
GPU [work-efficient]: 22.1805 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.01667e-05+-3.72678e-07 s
CPU: 1611.54 millions/s
GPU [work-efficient]: 0.000238667+-1.24722e-06 s
GPU [work-efficient]: 68.648 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.1e-05+-0 s
CPU: 1598.44 millions/s
GPU [work-efficient]: 0.000353833+-3.38707e-06 s
GPU [work-efficient]: 185.217 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162+-0 s
CPU: 1618.17 millions/s
GPU [work-efficient]: 0.0010625+-0.000360787 s
GPU [work-efficient]: 246.724 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000649667+-2.68742e-06 s
CPU: 1614.02 millions/s
GPU [work-efficient]: 0.00174383+-4.84748e-05 s
GPU [work-efficient]: 601.305 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00263167+-3.29983e-06 s
CPU: 1593.78 millions/s
GPU [work-efficient]: 0.00463867+-0.000112703 s
GPU [work-efficient]: 904.205 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0358473+-8.17e-05 s
CPU: 468.019 millions/s
GPU [work-efficient]: 0.0273298+-0.000241145 s
GPU [work-efficient]: 613.879 millions/s

</pre>

</p></details>