### PR TITLE
Task07 Дениль Шарипов СПбГУ

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,19 @@
-// TODO
+__kernel void reduce(__global const unsigned int* a, __global unsigned int* b) {
+    int i = get_global_id(0);
+
+    b[i] = a[2 * i] + a[2 * i + 1];
+}
+
+__kernel void down_sweep(__global const unsigned int* a, __global unsigned int* b) {
+    int i = get_global_id(0);
+
+    if (i == 0) {
+        return;
+    }
+
+    if (i % 2) {
+        b[i] = a[i / 2];
+    } else {
+        b[i] += a[i / 2 - 1];
+    }
+}

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -47,6 +47,12 @@ std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
 	for (unsigned int n = 4096; n <= max_n; n *= 4) {
 		std::cout << "______________________________________________" << std::endl;
 		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
@@ -83,20 +89,42 @@ int main(int argc, char **argv)
 #endif
 
 // work-efficient prefix sum
-#if 0
+#if 1
         {
             std::vector<unsigned int> res(n);
 
+            std::vector<gpu::gpu_mem_32u> as_gpus;
+            for(int d = 1; d <= n; d <<= 1) {
+                gpu::gpu_mem_32u as_gpu;
+                as_gpu.resizeN(n / d);
+                as_gpus.push_back(std::move(as_gpu));
+            }
+
+            ocl::Kernel reduce(prefix_sum_kernel, prefix_sum_kernel_length, "reduce");
+            reduce.compile();
+
+            ocl::Kernel down_sweep(prefix_sum_kernel, prefix_sum_kernel_length, "down_sweep");
+            down_sweep.compile();
+
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
+                as_gpus[0].writeN(as.data(), n);
                 t.restart();
-                // TODO
+                for (int logd = 1; logd < as_gpus.size(); logd++) {
+                    const int curn = n / (1 << logd);
+                    reduce.exec(gpu::WorkSize(std::min(curn, 128), curn), as_gpus[logd - 1], as_gpus[logd]);
+                }
+                for (int logd = as_gpus.size() - 2; logd >= 0; logd--) {
+                    const int curn = n / (1 << logd);
+                    down_sweep.exec(gpu::WorkSize(std::min(curn, 128), curn), as_gpus[logd + 1], as_gpus[logd]);
+                }
                 t.nextLap();
             }
 
             std::cout << "GPU [work-efficient]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU [work-efficient]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpus[0].readN(res.data(), n);
 
             for (int i = 0; i < n; ++i) {
                 EXPECT_THE_SAME(cpu_reference[i], res[i], "GPU result should be consistent!");


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2660 v4 @ 2.00GHz. Intel(R) Corporation. Total memory: 48182 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 5.1e-05+-5.41603e-06 s
CPU: 80.3137 millions/s
GPU [work-efficient]: 0.0010325+-0.000176007 s
GPU [work-efficient]: 3.96707 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000205333+-1.0435e-05 s
CPU: 79.7922 millions/s
GPU [work-efficient]: 0.0011985+-0.000133062 s
GPU [work-efficient]: 13.6704 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000704833+-3.4256e-05 s
CPU: 92.9808 millions/s
GPU [work-efficient]: 0.00136983+-0.000133196 s
GPU [work-efficient]: 47.8423 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00273+-7.0819e-05 s
CPU: 96.0234 millions/s
GPU [work-efficient]: 0.00208333+-0.000261441 s
GPU [work-efficient]: 125.829 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0109018+-0.000138256 s
CPU: 96.1835 millions/s
GPU [work-efficient]: 0.00254333+-0.000254689 s
GPU [work-efficient]: 412.284 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0449062+-0.000836081 s
CPU: 93.4015 millions/s
GPU [work-efficient]: 0.00662017+-0.00332445 s
GPU [work-efficient]: 633.565 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.189886+-0.00766248 s
CPU: 88.354 millions/s
GPU [work-efficient]: 0.013328+-0.000931415 s
GPU [work-efficient]: 1258.79 millions/s
</pre>

</p></details>
<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 4.16667e-06+-3.72678e-07 s
CPU: 983.04 millions/s
GPU [work-efficient]: 0.000202167+-4.48764e-06 s
GPU [work-efficient]: 20.2605 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.81667e-05+-3.72678e-07 s
CPU: 901.872 millions/s
GPU [work-efficient]: 0.000236667+-4.71405e-06 s
GPU [work-efficient]: 69.2282 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4e-05+-4.54747e-13 s
CPU: 1638.4 millions/s
GPU [work-efficient]: 0.0004095+-1.08282e-05 s
GPU [work-efficient]: 160.039 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162167+-3.72678e-07 s
CPU: 1616.51 millions/s
GPU [work-efficient]: 0.000820167+-5.40044e-05 s
GPU [work-efficient]: 319.623 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000647333+-4.71405e-07 s
CPU: 1619.84 millions/s
GPU [work-efficient]: 0.001922+-6.01775e-05 s
GPU [work-efficient]: 545.565 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00262667+-2.62467e-06 s
CPU: 1596.82 millions/s
GPU [work-efficient]: 0.00602183+-1.87742e-05 s
GPU [work-efficient]: 696.516 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0122763+-2.86221e-05 s
CPU: 1366.63 millions/s
GPU [work-efficient]: 0.0224448+-4.1679e-05 s
GPU [work-efficient]: 747.487 millions/s
</pre>

</p></details>