### PR TITLE
Task07 Валерий Мацкевич HSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 build
 cmake-build*
 .vs
+.vscode
+.history
+.gdb_history

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -15,3 +15,35 @@ __kernel void prefix_sum_naive(__global const unsigned int *array,
         result[gid] += array[gid - chunk_size];
     }
 }
+
+__kernel void prefix_sum_up_sweep(__global unsigned int *array,
+                                  unsigned int chunk_size,
+                                  unsigned int array_size)
+{
+    const unsigned int gid = get_global_id(0);
+
+    const unsigned int src = gid * chunk_size + chunk_size / 2 - 1;
+    const unsigned int dst = (gid + 1) * chunk_size - 1;
+
+    if (array_size <= src || array_size <= dst) {
+        return;
+    }
+
+    array[dst] += array[src];
+}
+
+__kernel void prefix_sum_down_sweep(__global unsigned int *array,
+                                    unsigned int chunk_size,
+                                    unsigned int array_size)
+{
+    const unsigned int gid = get_global_id(0);
+
+    const unsigned int src = (gid + 1) * chunk_size - 1;
+    const unsigned int dst = (gid + 1) * chunk_size + chunk_size / 2 - 1;
+
+    if (array_size <= src || array_size <= dst) {
+        return;
+    }
+
+    array[dst] += array[src];
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -6,14 +6,9 @@
 
 __kernel void prefix_sum_naive(__global const unsigned int *array,
                                __global unsigned int *result,
-                               unsigned int chunk_size,
-                               unsigned int array_size)
+                               unsigned int chunk_size)
 {
     const unsigned int gid = get_global_id(0);
-
-    if (array_size <= gid) {
-        return;
-    }
 
     result[gid] = array[gid];
     if (chunk_size <= gid) {

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,22 @@
-// TODO
+#ifdef __CLION_IDE__
+#include "clion_defines.cl"
+#endif
+
+#line 5
+
+__kernel void prefix_sum_naive(__global const unsigned int *array,
+                               __global unsigned int *result,
+                               unsigned int chunk_size,
+                               unsigned int array_size)
+{
+    const unsigned int gid = get_global_id(0);
+
+    if (array_size <= gid) {
+        return;
+    }
+
+    result[gid] = array[gid];
+    if (chunk_size <= gid) {
+        result[gid] += array[gid - chunk_size];
+    }
+}

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,8 +1,8 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
@@ -13,18 +13,16 @@ const int benchmarkingItersCPU = 10;
 const unsigned int max_n = (1 << 24);
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
-std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
-{
+std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as) {
     const unsigned int n = as.size();
 
     std::vector<unsigned int> bs(n);
@@ -33,7 +31,7 @@ std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
         for (int i = 0; i < n; ++i) {
             bs[i] = as[i];
             if (i) {
-                bs[i] += bs[i-1];
+                bs[i] += bs[i - 1];
             }
         }
         t.nextLap();
@@ -45,33 +43,54 @@ std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
     return bs;
 }
 
-int main(int argc, char **argv)
-{
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    ocl::Kernel prefixSumNaive(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_naive");
+    prefixSumNaive.compile();
+
+    for (unsigned int n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
         const std::vector<unsigned int> cpu_reference = computeCPU(as);
 
 // prefix sum
-#if 0
+#if 1
         {
+            gpu::gpu_mem_32u as_gpu;
+            gpu::gpu_mem_32u pref_gpu;
+            as_gpu.resizeN(n);
+            pref_gpu.resizeN(n);
+
+            gpu::WorkSize workSize(64, n);
+
             std::vector<unsigned int> res(n);
 
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
+                as_gpu.writeN(as.data(), n);
+
                 t.restart();
-                // TODO
+                for (unsigned int chunkSize = 1u; chunkSize < n; chunkSize *= 2u) {
+                    prefixSumNaive.exec(workSize, as_gpu, pref_gpu, chunkSize, n);
+
+                    std::swap(as_gpu, pref_gpu);
+                }
                 t.nextLap();
             }
+            as_gpu.readN(res.data(), n);
 
             std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
@@ -103,5 +122,5 @@ int main(int argc, char **argv)
             }
         }
 #endif
-	}
+    }
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
 
                 t.restart();
                 for (unsigned int chunkSize = 1u; chunkSize < n; chunkSize *= 2u) {
-                    prefixSumNaive.exec(workSize, as_gpu, pref_gpu, chunkSize, n);
+                    prefixSumNaive.exec(workSize, as_gpu, pref_gpu, chunkSize);
 
                     std::swap(as_gpu, pref_gpu);
                 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./build/prefix_sum 
OpenCL devices:
  Device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
Using device #0: CPU. pthread-AMD Ryzen 5 5500U with Radeon Graphics. AuthenticAMD. Total memory: 13334 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.2e-05+-4.54747e-13 s
CPU: 186.182 millions/s
GPU [work-efficient]: 0.00164267+-5.44906e-05 s
GPU [work-efficient]: 2.49351 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000241+-4.4556e-12 s
CPU: 67.9834 millions/s
GPU [work-efficient]: 0.0019595+-8.83681e-05 s
GPU [work-efficient]: 8.36132 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000366333+-1.73941e-05 s
CPU: 178.897 millions/s
GPU [work-efficient]: 0.00225333+-0.000179673 s
GPU [work-efficient]: 29.084 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.001458+-2.05508e-05 s
CPU: 179.797 millions/s
GPU [work-efficient]: 0.00303817+-3.52109e-05 s
GPU [work-efficient]: 86.2836 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00585133+-6.33474e-05 s
CPU: 179.203 millions/s
GPU [work-efficient]: 0.0044245+-0.000122579 s
GPU [work-efficient]: 236.993 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0230777+-9.33732e-05 s
CPU: 181.747 millions/s
GPU [work-efficient]: 0.0236132+-0.000257969 s
GPU [work-efficient]: 177.626 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.111935+-0.0046631 s
CPU: 149.884 millions/s
GPU [work-efficient]: 0.094643+-0.000253588 s
GPU [work-efficient]: 177.268 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
./prefix_sum
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2e-06+-0 s
CPU: 2048 millions/s
GPU: 0.0001665+-4.85627e-06 s
GPU: 24.6006 millions/s
GPU [work-efficient]: 0.000196+-1.1547e-06 s
GPU [work-efficient]: 20.898 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.23333e-05+-5.21749e-06 s
CPU: 1328.43 millions/s
GPU: 0.000282667+-3.39935e-06 s
GPU: 57.9623 millions/s
GPU [work-efficient]: 0.000262833+-3.02306e-06 s
GPU [work-efficient]: 62.3361 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.1e-05+-0 s
CPU: 1598.44 millions/s
GPU: 0.000496+-8.06226e-06 s
GPU: 132.129 millions/s
GPU [work-efficient]: 0.000400667+-6.79869e-06 s
GPU [work-efficient]: 163.567 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000166+-2.3094e-06 s
CPU: 1579.18 millions/s
GPU: 0.00127133+-2.0629e-05 s
GPU: 206.196 millions/s
GPU [work-efficient]: 0.000787+-8.02081e-06 s
GPU [work-efficient]: 333.093 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000654667+-5.52771e-06 s
CPU: 1601.69 millions/s
GPU: 0.00415333+-6.87063e-05 s
GPU: 252.466 millions/s
GPU [work-efficient]: 0.00191683+-2.79906e-05 s
GPU [work-efficient]: 547.036 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00263283+-7.55903e-06 s
CPU: 1593.08 millions/s
GPU: 0.0159145+-5.66032e-05 s
GPU: 263.552 millions/s
GPU [work-efficient]: 0.00599967+-0.000120206 s
GPU [work-efficient]: 699.09 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.012276+-7.14143e-06 s
CPU: 1366.67 millions/s
GPU: 0.0849708+-0.000290562 s
GPU: 197.447 millions/s
GPU [work-efficient]: 0.0297448+-0.000776804 s
GPU [work-efficient]: 564.038 millions/s
</pre>

</p></details>

### Баг POCL?

Кажется, что POCL погибает страшной смертью с `SEGFAULT` на моей машине в случае наивной префиксной суммы. Почему: неясно, только выяснил что программа ложится на `chunkSize == groupSize`. (Очень хочу верить что это баг компилятора а не мой :))

Причём, с `oclgrind`, проблема не стреляет... всё отрабатывает штатно даже на `prefix_sum_naive`. 

**В локальном выводе только умная версия префиксной суммы, наивный алгоритм сегфолтится локально под POCL**