### PR TITLE
Task07 Лопатин Алексей HSE

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,10 @@
-// TODO
+__kernel void prefix_sum(__global const unsigned int* as, __global unsigned int* prefix_sum, unsigned int offset) {
+    unsigned int gid = get_global_id(0);
+
+    if (gid < offset) {
+        prefix_sum[gid] = as[gid];
+        return;
+    }
+
+    prefix_sum[gid] = as[gid - offset] + as[gid];
+}


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.1e-05+-1.58726e-13 s
CPU: 195.048 millions/s
GPU: 0.00282433+-5.09401e-05 s
GPU: 1.45025 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 7.2e-05+-0 s
CPU: 227.556 millions/s
GPU: 0.00344883+-0.000138969 s
GPU: 4.75059 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000292333+-3.77124e-06 s
CPU: 224.182 millions/s
GPU: 0.00390817+-9.02504e-05 s
GPU: 16.769 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00116983+-1.94886e-05 s
CPU: 224.087 millions/s
GPU: 0.00580383+-0.000210513 s
GPU: 45.1674 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00486183+-3.10881e-05 s
CPU: 215.675 millions/s
GPU: 0.00708367+-0.000207509 s
GPU: 148.027 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0190185+-0.000137476 s
CPU: 220.538 millions/s
GPU: 0.00883133+-5.11751e-05 s
GPU: 474.934 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0750455+-0.000123428 s
CPU: 223.561 millions/s
GPU: 0.0244508+-0.000195857 s
GPU: 686.161 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2e-06+-0 s
CPU: 2048 millions/s
GPU: 0.000168667+-1.71626e-05 s
GPU: 24.2846 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.81667e-05+-6.87184e-07 s
CPU: 901.872 millions/s
GPU: 0.000263833+-3.57849e-06 s
GPU: 62.0998 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.1e-05+-0 s
CPU: 1598.44 millions/s
GPU: 0.000502833+-1.06992e-05 s
GPU: 130.333 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000164833+-2.91071e-06 s
CPU: 1590.36 millions/s
GPU: 0.0012365+-4.35421e-05 s
GPU: 212.005 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000652+-3.55903e-06 s
CPU: 1608.25 millions/s
GPU: 0.00372683+-0.000160485 s
GPU: 281.358 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0026345+-9.41187e-06 s
CPU: 1592.07 millions/s
GPU: 0.0140255+-9.315e-05 s
GPU: 299.048 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0391727+-0.000132633 s
CPU: 428.289 millions/s
GPU: 0.0840925+-0.000670642 s
GPU: 199.509 millions/s
</pre>

</p></details>
