### PR TITLE
Task07 Igor Bereza SPbU 

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,19 @@
-// TODO
+__kernel void naive_prefix_sum(
+    const __global unsigned int *data,
+    unsigned int n,
+    unsigned int block_size,
+    __global unsigned int *out
+)
+{
+    const int i = get_global_id(0);
+    if (i >= n) {
+        return;
+    }
+
+    if (i < block_size) {
+        out[i] = data[i];
+    } else {
+        out[i] = data[i] + data[i - block_size];
+    }
+}
+


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) Arc(TM) A770 Graphics. Total memory: 15930 Mb
Using device #0: GPU. Intel(R) Arc(TM) A770 Graphics. Total memory: 15930 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.9e-05+-0 s
CPU: 141.241 millions/s
GPU: 0.001273+-0.000596641 s
GPU: 3.2176 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000126+-1.28062e-05 s
CPU: 130.032 millions/s
GPU: 0.0008615+-9.19692e-06 s
GPU: 19.018 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000475667+-8.21922e-06 s
CPU: 137.777 millions/s
GPU: 0.001139+-1.57374e-05 s
GPU: 57.5382 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00188683+-4.0586e-06 s
CPU: 138.933 millions/s
GPU: 0.001504+-8.5049e-06 s
GPU: 174.298 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00785333+-0.000232579 s
CPU: 133.52 millions/s
GPU: 0.00203433+-1.27105e-05 s
GPU: 515.44 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.031371+-0.000300718 s
CPU: 133.7 millions/s
GPU: 0.00342783+-0.00010882 s
GPU: 1223.6 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.126176+-0.000345857 s
CPU: 132.967 millions/s
GPU: 0.00937933+-8.81848e-05 s
GPU: 1788.74 millions/s
</pre>

</p></details>
<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.83333e-06+-8.97527e-07 s
CPU: 1445.65 millions/s
GPU: 0.000152667+-6.18241e-06 s
GPU: 26.8297 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.36667e-05+-3.68179e-06 s
CPU: 1198.83 millions/s
GPU: 0.0002345+-2.75379e-06 s
GPU: 69.8678 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.3e-05+-0 s
CPU: 1524.09 millions/s
GPU: 0.000482333+-7.60847e-06 s
GPU: 135.873 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162+-0 s
CPU: 1618.17 millions/s
GPU: 0.00117417+-1.87742e-05 s
GPU: 223.26 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000647167+-3.72678e-07 s
CPU: 1620.26 millions/s
GPU: 0.00358967+-9.68034e-05 s
GPU: 292.11 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00263617+-1.32088e-05 s
CPU: 1591.06 millions/s
GPU: 0.0137233+-8.1859e-05 s
GPU: 305.633 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0400223+-0.000119374 s
CPU: 419.196 millions/s
GPU: 0.0919798+-0.0010381 s
GPU: 182.401 millions/s
</pre>
</p></details>