### PR TITLE
Task08 Даниил Ушков ITMO

### DIFF
--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -44,9 +44,20 @@ __kernel void count(__global unsigned int *as, __global unsigned int *cs, unsign
 
     unsigned int val = as[gid];
     unsigned int digit = get_digit(val, digit_no);
+#if 0
+    printf("gid=%d lid=%d wid=%d val=%d digit=%d\n", gid, lid, wid, val, digit);
+#endif
     atomic_add(&cs_local[digit], 1);
 
     barrier(CLK_LOCAL_MEM_FENCE);
+
+#if 0
+    if (lid == 0) {
+        for (unsigned int i = 0; i < N_DIGITS; i++) {
+            printf("gid=%d lid=%d wid=%d cs_local[%d]=%d\n", gid, lid, wid, i, cs_local[i]);
+        }
+    }
+#endif
 
     if (lid < N_DIGITS) {
         unsigned digit = lid;

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -22,10 +22,17 @@
 #error "Constant not defined."
 #endif
 
+unsigned int get_digit(unsigned int val, unsigned int digit_no) {
+    unsigned int low = digit_no;
+    unsigned int up = 32 - (digit_no + 1);
+    return ((val << (up * BITS_PER_DIGIT)) >> ((up + low) * BITS_PER_DIGIT));
+}
+
 __kernel void count(__global unsigned int *as, __global unsigned int *cs, unsigned int digit_no)
 {
     unsigned int gid = get_global_id(0);
     unsigned int lid = get_local_id(0);
+    unsigned int wid = gid / WORK_GROUP_SIZE;
 
     __local unsigned int cs_local[N_DIGITS];
 
@@ -43,7 +50,8 @@ __kernel void count(__global unsigned int *as, __global unsigned int *cs, unsign
     barrier(CLK_LOCAL_MEM_FENCE);
 
     if (lid < N_DIGITS) {
-        cs[...] = cs_local[lid];
+        unsigned digit = lid;
+        cs[wid * N_DIGITS + digit] = cs_local[digit];
     }
 }
 

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -44,20 +44,9 @@ __kernel void count(__global unsigned int *as, __global unsigned int *cs, unsign
 
     unsigned int val = as[gid];
     unsigned int digit = get_digit(val, digit_no);
-#if 0
-    printf("gid=%d lid=%d wid=%d val=%d digit=%d\n", gid, lid, wid, val, digit);
-#endif
     atomic_add(&cs_local[digit], 1);
 
     barrier(CLK_LOCAL_MEM_FENCE);
-
-#if 0
-    if (lid == 0) {
-        for (unsigned int i = 0; i < N_DIGITS; i++) {
-            printf("gid=%d lid=%d wid=%d cs_local[%d]=%d\n", gid, lid, wid, i, cs_local[i]);
-        }
-    }
-#endif
 
     if (lid < N_DIGITS) {
         unsigned digit = lid;
@@ -131,12 +120,6 @@ __kernel void move(__global unsigned int *as, __global unsigned int *bs, __globa
             idx++;
         }
     }
-
-#if 0
-    if (wid == 0) {
-        printf("gid=%d lid=%d wid=%d idx=%d\n", gid, lid, wid, idx);
-    }
-#endif
 
     bs[idx] = buf[lid];
 }

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,1 +1,40 @@
-// TODO
+__kernel void count()
+{
+    /* TODO */
+}
+
+__kernel void transpose()
+{
+    /* TODO */
+}
+
+__kernel void up_sweep(__global unsigned int *as, unsigned int n, int d)
+{
+    unsigned int idx = get_global_id(0);
+    if (idx >= (n >> (d + 1))) {
+        return;
+    }
+    unsigned int k = idx << (d + 1);
+    unsigned int k1 = k + (1 << d) - 1;
+    unsigned int k2 = k + (1 << (d + 1)) - 1;
+    as[k2] = k2 != n - 1 ? as[k1] + as[k2] : 0;
+}
+
+__kernel void down_sweep(__global unsigned int *as, unsigned int n, int d)
+{
+    unsigned int idx = get_global_id(0);
+    if (idx >= (n >> (d + 1))) {
+        return;
+    }
+    unsigned int k = idx << (d + 1);
+    unsigned int k1 = k + (1 << d) - 1;
+    unsigned int k2 = k + (1 << (d + 1)) - 1;
+    unsigned int tmp = as[k1];
+    as[k1] = as[k2];
+    as[k2] = tmp + as[k2];
+}
+
+__kernel void move()
+{
+    /* TODO */
+}

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -22,9 +22,29 @@
 #error "Constant not defined."
 #endif
 
-__kernel void count(__global unsigned int *as, __global unsigned int *cs)
+__kernel void count(__global unsigned int *as, __global unsigned int *cs, unsigned int digit_no)
 {
-    /* TODO */
+    unsigned int gid = get_global_id(0);
+    unsigned int lid = get_local_id(0);
+
+    __local unsigned int cs_local[N_DIGITS];
+
+    if (lid < N_DIGITS) {
+        cs_local[lid] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (gid < WORK_SIZE) {
+        unsigned int val = as[gid];
+        atomic_add(&cs_local[get_digit(val, digit_no)], 1);
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid < N_DIGITS) {
+        cs[...] = cs_local[lid];
+    }
 }
 
 __kernel void transpose(__global unsigned int *as, __global unsigned int *as_t)

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -120,5 +120,5 @@ __kernel void move(__global unsigned int *as, __global unsigned int *bs, __globa
         }
     }
 
-    bs[idx] = val;
+    bs[idx] = buf[lid];
 }

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -120,16 +120,23 @@ __kernel void move(__global unsigned int *as, __global unsigned int *bs, __globa
     __local unsigned int buf[WORK_GROUP_SIZE];
 
     buf[lid] = as[gid];
-    unsigned int digit = get_digit(buf[lid], digit_no);
-    unsigned int idx = cs_t[N_WORK_GROUPS * digit + wid];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
+    unsigned int digit = get_digit(buf[lid], digit_no);
+    unsigned int idx = cs_t[N_WORK_GROUPS * digit + wid];
     for (unsigned int i = 0; i < lid; i++) {
-        if (buf[i] <= buf[lid]) {
+        unsigned int digit1 = get_digit(buf[i], digit_no);
+        if (digit1 == digit) {
             idx++;
         }
     }
+
+#if 0
+    if (wid == 0) {
+        printf("gid=%d lid=%d wid=%d idx=%d\n", gid, lid, wid, idx);
+    }
+#endif
 
     bs[idx] = buf[lid];
 }

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,11 +1,50 @@
-__kernel void count()
+#ifndef WORK_SIZE
+#error "Constant not defined."
+#endif
+
+#ifndef WORK_GROUP_SIZE
+#error "Constant not defined."
+#endif
+
+#ifndef N_WORK_GROUPS
+#error "Constant not defined."
+#endif
+
+#ifndef BITS_PER_DIGIT
+#error "Constant not defined."
+#endif
+
+#ifndef N_DIGITS
+#error "Constant not defined."
+#endif
+
+#ifndef TILE_SIZE
+#error "Constant not defined."
+#endif
+
+__kernel void count(__global unsigned int *as, __global unsigned int *cs)
 {
     /* TODO */
 }
 
-__kernel void transpose()
+__kernel void transpose(__global unsigned int *as, __global unsigned int *as_t)
 {
-    /* TODO */
+    unsigned int M = N_WORK_GROUPS;
+    unsigned int K = N_DIGITS;
+
+    unsigned int j = get_global_id(0);
+    unsigned int i = get_global_id(1);
+
+    __local unsigned int tile[TILE_SIZE + 1][TILE_SIZE];
+
+    unsigned int local_j = get_local_id(0);
+    unsigned int local_i = get_local_id(1);
+
+    tile[local_i][local_j] = as[K * i + j];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[M * j + i] = tile[local_i][local_j];
 }
 
 __kernel void up_sweep(__global unsigned int *as, unsigned int n, int d)

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -147,6 +147,8 @@ int main(int argc, char **argv) {
         std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
+    as_gpu.readN(as.data(), workSize);
+
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_reference[i], "GPU results should be equal to CPU results!");

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -76,11 +76,11 @@ int main(int argc, char **argv) {
     const std::vector<unsigned int> cpu_reference = computeCPU(as);
 
     unsigned int workSize = n;
-    unsigned int workGroupSize = 4;
+    unsigned int workGroupSize = 64;
     unsigned int nWorkGroups = workSize / workGroupSize;
-    unsigned int bitsPerDigit = 2;
+    unsigned int bitsPerDigit = 4;
     unsigned int nDigits = (1 << bitsPerDigit);
-    unsigned int tileSize = 2;
+    unsigned int tileSize = 8;
 
     assert(nDigits <= workGroupSize);
     assert(tileSize * tileSize == workGroupSize);

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -44,7 +44,7 @@ std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
 }
 
 unsigned int mylog(unsigned int n) {
-    return 32 - __builtin_clz(n);
+    return 31 - __builtin_clz(n);
 }
 
 void execPrefixSum(ocl::Kernel &up_sweep, ocl::Kernel &down_sweep, gpu::gpu_mem_32u &as_gpu, unsigned int workSize, unsigned int workGroupSize) {
@@ -123,13 +123,14 @@ int main(int argc, char **argv) {
 
                 std::vector<unsigned int> debug_buf1;
                 debug_buf1.resize(nWorkGroups * nDigits);
-                cs_gpu.readN(debug_buf1.data(), nWorkGroups * nDigits);
+                cs_t_gpu.readN(debug_buf1.data(), nWorkGroups * nDigits);
+
+                execPrefixSum(up_sweep, down_sweep, cs_t_gpu, nWorkGroups * nDigits, workGroupSize);
 
                 std::vector<unsigned int> debug_buf2;
                 debug_buf2.resize(nWorkGroups * nDigits);
                 cs_t_gpu.readN(debug_buf2.data(), nWorkGroups * nDigits);
 
-                execPrefixSum(up_sweep, down_sweep, cs_t_gpu, nWorkGroups * nDigits, workGroupSize);
                 move.exec({workGroupSize, workSize}, as_gpu, bs_gpu, cs_t_gpu, digit_no);
             }
             t.nextLap();

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -120,23 +120,8 @@ int main(int argc, char **argv) {
             for (unsigned int digit_no = 0; digit_no < (32 / bitsPerDigit); digit_no++) {
                 count.exec({workGroupSize, workSize}, as_gpu, cs_gpu, digit_no);
                 transpose.exec({tileSize, tileSize, nDigits, nWorkGroups}, cs_gpu, cs_t_gpu);
-
-                std::vector<unsigned int> debug_buf1;
-                debug_buf1.resize(nWorkGroups * nDigits);
-                cs_t_gpu.readN(debug_buf1.data(), nWorkGroups * nDigits);
-
                 execPrefixSum(up_sweep, down_sweep, cs_t_gpu, nWorkGroups * nDigits, workGroupSize);
-
-                std::vector<unsigned int> debug_buf2;
-                debug_buf2.resize(nWorkGroups * nDigits);
-                cs_t_gpu.readN(debug_buf2.data(), nWorkGroups * nDigits);
-
                 move.exec({workGroupSize, workSize}, as_gpu, bs_gpu, cs_t_gpu, digit_no);
-
-                std::vector<unsigned int> debug_buf3;
-                debug_buf3.resize(workSize);
-                bs_gpu.readN(debug_buf3.data(), workSize);
-
                 std::swap(as_gpu, bs_gpu);
             }
             t.nextLap();

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -132,6 +132,12 @@ int main(int argc, char **argv) {
                 cs_t_gpu.readN(debug_buf2.data(), nWorkGroups * nDigits);
 
                 move.exec({workGroupSize, workSize}, as_gpu, bs_gpu, cs_t_gpu, digit_no);
+
+                std::vector<unsigned int> debug_buf3;
+                debug_buf3.resize(workSize);
+                bs_gpu.readN(debug_buf3.data(), workSize);
+
+                std::swap(as_gpu, bs_gpu);
             }
             t.nextLap();
         }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -12,9 +12,9 @@
 #include <vector>
 #include <assert.h>
 
-const int benchmarkingIters = 1;
+const int benchmarkingIters = 10;
 const int benchmarkingItersCPU = 1;
-const unsigned int n = 32;
+const unsigned int n = 32 * 1024 * 1024;
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
     std::vector<unsigned int> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
-        as[i] = (unsigned int) r.next(0, std::numeric_limits<int>::max()) % 4;
+        as[i] = (unsigned int) r.next(0, std::numeric_limits<int>::max());
     }
     std::cout << "Data generated for n=" << n << "!" << std::endl;
 


### PR DESCRIPTION
```
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-1260P. Intel(R) Corporation. Total memory: 31716 Mb
Using device #0: CPU. 12th Gen Intel(R) Core(TM) i7-1260P. Intel(R) Corporation. Total memory: 31716 Mb
Data generated for n=33554432!
CPU: 9.11103+-0 s
CPU: 3.62198 millions/s
Building kernels for 12th Gen Intel(R) Core(TM) i7-1260P... 
Kernels compilation done in 0.102148 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <count> was successfully vectorized (8)
Kernel <transpose> was successfully vectorized (8)
Kernel <up_sweep> was successfully vectorized (8)
Kernel <down_sweep> was not vectorized
Kernel <move> was successfully vectorized (8)
Done.

Building kernels for 12th Gen Intel(R) Core(TM) i7-1260P... 
Kernels compilation done in 0.094111 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <count> was successfully vectorized (8)
Kernel <transpose> was successfully vectorized (8)
Kernel <up_sweep> was successfully vectorized (8)
Kernel <down_sweep> was not vectorized
Kernel <move> was successfully vectorized (8)
Done.

Building kernels for 12th Gen Intel(R) Core(TM) i7-1260P... 
Kernels compilation done in 0.095193 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <count> was successfully vectorized (8)
Kernel <transpose> was successfully vectorized (8)
Kernel <up_sweep> was successfully vectorized (8)
Kernel <down_sweep> was not vectorized
Kernel <move> was successfully vectorized (8)
Done.

Building kernels for 12th Gen Intel(R) Core(TM) i7-1260P... 
Kernels compilation done in 0.096905 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <count> was successfully vectorized (8)
Kernel <transpose> was successfully vectorized (8)
Kernel <up_sweep> was successfully vectorized (8)
Kernel <down_sweep> was not vectorized
Kernel <move> was successfully vectorized (8)
Done.

GPU: 0.869951+-0.00291781 s
GPU: 38.5705 millions/s
```

Видим ускорение почти в 3 раза относительно merge sort и почти в 6 раз относительно bitonic sort.