### PR TITLE
Task08 Алексей Казаков ITMO

### DIFF
--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,1 +1,102 @@
-// TODO
+__kernel void write_zeros(__global unsigned int* buf, unsigned int n) {
+    const size_t i = get_global_id(0);
+    if (i < n) {
+        buf[i] = 0;
+    }
+}
+
+#define TILE_SIZE 16
+__kernel void transpose(
+    __global const float* in,
+    __global float* out,
+    unsigned int M,
+    unsigned int K
+)
+{
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (i >= K || j >= M) {
+        return;
+    }
+
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+
+    __local float local_buffer[TILE_SIZE][TILE_SIZE + 1];
+
+    local_buffer[local_j][local_i] = in[j * K + i];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const unsigned int target_i = i - local_i + local_j;
+    const unsigned int target_j = j - local_j + local_i;
+
+    out[target_i * M + target_j] = local_buffer[local_i][local_j];
+}
+#undef TILE_SIZE
+
+__kernel void prefix_sum_pass1(
+    __global unsigned int* as,
+    unsigned int as_size,
+    unsigned int block_size
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int last_in_block = (1 + i) * block_size - 1;
+    unsigned int mid_in_block = last_in_block - block_size / 2;
+    if (last_in_block < as_size) {
+        as[last_in_block] = as[mid_in_block] + as[last_in_block];
+    }
+}
+
+__kernel void prefix_sum_pass2(
+    __global unsigned int* as,
+    unsigned int as_size,
+    unsigned int block_size
+) {
+    unsigned int i = get_global_id(0);
+    unsigned int target_i = (1 + i) * block_size * 2 + block_size - 1;
+    if (target_i < as_size) {
+        as[target_i] = as[target_i - block_size] + as[target_i];
+    }
+}
+
+#define NBITS 4
+__kernel void count(
+    __global const unsigned int* as,
+    unsigned int n,
+    __global unsigned int* buf,
+    unsigned int bit_shift
+) {
+    const size_t i = get_global_id(0);
+    if (i < n) {
+        const size_t wg_id = i / get_local_size(0);
+        const unsigned int ndigits = 1 << NBITS;
+        const unsigned int d = (as[i] >> bit_shift) & (ndigits - 1);
+        atomic_inc(&buf[wg_id * ndigits + d]);
+    }
+}
+
+__kernel void sort(
+    __global const unsigned int* as,
+    __global unsigned int* bs,
+    unsigned int n,
+    __global const unsigned int* buf,
+    unsigned int bit_shift
+) {
+    const size_t i = get_global_id(0);
+    if (i < n) {
+        const size_t nwg = get_global_size(0) / get_local_size(0);
+        const size_t wg_id = i / get_local_size(0);
+        const unsigned int ndigits = 1 << NBITS;
+        const unsigned int d = (as[i] >> bit_shift) & (ndigits - 1);
+        unsigned int count_i = d * nwg + wg_id;
+        unsigned int place = count_i > 0 ? buf[count_i - 1] : 0;
+
+        for (unsigned int k = wg_id * get_local_size(0); k < i; ++k) {
+            place += ((as[k] >> bit_shift) & (ndigits - 1)) == d;
+        }
+
+        bs[place] = as[i];
+    }
+}
+#undef NBITS

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -7,6 +7,8 @@
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/radix_cl.h"
 
+#include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
@@ -49,6 +51,11 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
+    gpu::gpu_mem_32u as_gpu;
+    gpu::gpu_mem_32u bs_gpu;
+    gpu::gpu_mem_32u buf1_gpu;
+    gpu::gpu_mem_32u buf2_gpu;
+
     std::vector<unsigned int> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -58,21 +65,163 @@ int main(int argc, char **argv) {
 
     const std::vector<unsigned int> cpu_reference = computeCPU(as);
 
-    // remove me
-    return 0;
+    const unsigned int work_group_size = 128;
+    const unsigned int nbits = 4;
+    const unsigned int nwork_groups = (n + work_group_size - 1) / work_group_size;
+    const unsigned int buf_size = nwork_groups * (1 << nbits);
 
     {
+        as_gpu.resizeN(n);
+        bs_gpu.resizeN(n);
+        buf1_gpu.resizeN(buf_size);
+        buf2_gpu.resizeN(buf_size);
+
+        ocl::Kernel radix_write_zeros(
+            radix_kernel,
+            radix_kernel_length,
+            "write_zeros"
+        );
+        radix_write_zeros.compile();
+
+        ocl::Kernel radix_count(
+            radix_kernel,
+            radix_kernel_length,
+            "count"
+        );
+        radix_count.compile();
+
+        ocl::Kernel radix_transpose(
+            radix_kernel,
+            radix_kernel_length,
+            "transpose"
+        );
+        radix_transpose.compile();
+
+        ocl::Kernel radix_prefix_sum_pass1(
+            radix_kernel,
+            radix_kernel_length,
+            "prefix_sum_pass1"
+        );
+        radix_prefix_sum_pass1.compile();
+
+        ocl::Kernel radix_prefix_sum_pass2(
+            radix_kernel,
+            radix_kernel_length,
+            "prefix_sum_pass2"
+        );
+        radix_prefix_sum_pass2.compile();
+
+        ocl::Kernel radix_sort(
+            radix_kernel,
+            radix_kernel_length,
+            "sort"
+        );
+        radix_sort.compile();
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+            as_gpu.writeN(as.data(), n);
 
-            // TODO
+            // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+            t.restart();
+
+            for (
+                unsigned int bit_shift = 0;
+                bit_shift < 8 * sizeof(unsigned int);
+                bit_shift += nbits
+            ) {
+                // write zeros
+                {
+                    const unsigned int work_size = nwork_groups * (1 << nbits);
+                    radix_write_zeros.exec(
+                        gpu::WorkSize(work_group_size, work_size),
+                        buf1_gpu,
+                        buf_size
+                    );
+                }
+
+                // count
+                {
+                    const unsigned int work_size = nwork_groups * work_group_size;
+                    radix_count.exec(
+                        gpu::WorkSize(work_group_size, work_size),
+                        as_gpu,
+                        n,
+                        buf1_gpu,
+                        bit_shift
+                    );
+                }
+
+                // transpose
+                {
+                    const unsigned int M = nwork_groups;
+                    const unsigned int K = 1 << nbits;
+                    const unsigned int tile_size = std::min({M, K, 16u});
+                    assert((tile_size & (tile_size - 1)) == 0 && "tile_size should be a power of 2");
+                    radix_transpose.exec(
+                        gpu::WorkSize(
+                            tile_size,
+                            tile_size,
+                            tile_size * ((K + tile_size - 1) / tile_size),
+                            tile_size * ((M + tile_size - 1) / tile_size)
+                        ),
+                        buf1_gpu,
+                        buf2_gpu,
+                        M,
+                        K
+                    );
+                }
+
+                // prefix sum
+                {
+                    for (int block_size = 2; block_size <= buf_size; block_size *= 2) {
+                        unsigned int work_size = buf_size / block_size;
+                        work_size = work_group_size * ((work_size + work_group_size - 1) / work_group_size);
+                        radix_prefix_sum_pass1.exec(
+                            gpu::WorkSize(work_group_size, work_size),
+                            buf2_gpu,
+                            buf_size,
+                            block_size
+                        );
+                    }
+
+                    for (int block_size = buf_size / 4; block_size > 0; block_size /= 2) {
+                        unsigned int work_size = buf_size / (block_size * 2) - 1;
+                        work_size = work_group_size * ((work_size + work_group_size - 1) / work_group_size);
+                        radix_prefix_sum_pass2.exec(
+                            gpu::WorkSize(work_group_size, work_size),
+                            buf2_gpu,
+                            buf_size,
+                            block_size
+                        );
+                    }
+                }
+
+                // sort
+                {
+                    const unsigned int work_size = nwork_groups * work_group_size;
+                    radix_sort.exec(
+                        gpu::WorkSize(work_group_size, work_size),
+                        as_gpu,
+                        bs_gpu,
+                        n,
+                        buf2_gpu,
+                        bit_shift
+                    );
+                }
+
+                as_gpu.swap(bs_gpu);
+
+                t.nextLap();
+            }
         }
         t.stop();
 
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
+
+    as_gpu.readN(as.data(), n);
 
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {


### PR DESCRIPTION

<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 16084 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6433 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 6143 Mb
Data generated for n=33554432!
CPU: 2.10704+-0 s
CPU: 15.6618 millions/s
GPU: 0.0124518+-0.00018587 s
GPU: 2694.74 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
 OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.78377+-0 s
CPU: 11.8544 millions/s
GPU: 0.760646+-0.000660902 s
GPU: 44.1131 millions/s
</pre>

</p></details>

Можно заметить, что radix sort, использующий в реализации work-efficient prefix sum, заметно обгоняет merge sort и bitonic sort на выбранном размере массива $n = 32 \cdot 1024 \cdot 1024$:
- bitonic: ~100 millions/s
- merge: ~500 millions/s
- radix: ~2700 millions/s
