### PR TITLE
Task08 Андрей Гладких ITMO

### DIFF
--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,1 +1,91 @@
-// TODO
+#define WORKGROUP_SIZE (128)
+#define NBITS (4)
+#define TRANSPOSE_GROUP_SIZE (16)
+
+__kernel void write_zeros(__global unsigned int *as)
+{
+    as[get_global_id(0)] = 0;
+}
+
+__kernel void radix_count(__global unsigned int *as, __global unsigned int *counters, const unsigned int bit_shift)
+{
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int bit = (as[gid] >> bit_shift) & ((1 << NBITS) - 1);
+    atomic_inc(&counters[get_group_id(0) * (1 << NBITS) + bit]);
+}
+
+__kernel void radix_sort(__global unsigned int *as, __global unsigned int *bs, __global unsigned int *counters_transposed, const unsigned int bit_shift)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int bits[WORKGROUP_SIZE];
+    bits[lid] = (as[gid] >> bit_shift) & ((1 << NBITS) - 1);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // index of C_{wg}^{bit}
+    const unsigned int counters_idx = get_num_groups(0) * bits[lid] + get_group_id(0);
+    // since our prefix sum is inclusive
+    const unsigned int N_lower_than_me = (counters_idx == 0) ? 0 : counters_transposed[counters_idx - 1];
+
+    unsigned int N_equal_to_me = 0;
+    for (int i = 0; i < lid; ++i) {
+        if (bits[i] == bits[lid]) {
+            N_equal_to_me++;
+        }
+    }
+
+    bs[N_lower_than_me + N_equal_to_me] = as[gid];
+}
+
+// From previous homeworks, only added bounds check for matrix_transpose
+
+__kernel void matrix_transpose(__global unsigned int *as, __global unsigned int *bs, const unsigned int m, const unsigned int k)
+{
+    __local float block[TRANSPOSE_GROUP_SIZE][TRANSPOSE_GROUP_SIZE + 1];
+
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+    const unsigned int group_i = get_group_id(0);
+    const unsigned int group_j = get_group_id(1);
+
+    if (j < k && i < m) {
+        block[local_j][local_i] = as[j * m + i];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    
+    const unsigned int x = group_j * TRANSPOSE_GROUP_SIZE + local_i;
+    const unsigned int y = group_i * TRANSPOSE_GROUP_SIZE + local_j;
+
+    if (y < m && x < k) {
+        bs[y * k + x] = block[local_i][local_j];
+    }
+}
+
+__kernel void prefix_sum_up(__global unsigned int* as, const unsigned int n, const unsigned int step, const unsigned int workSize) {
+    const uint gid = get_global_id(0);
+
+    if (gid >= workSize) {
+        return;
+    }
+
+    as[step * (gid * 2 + 2) - 1] += as[step * (gid * 2 + 1) - 1];
+}
+
+__kernel void prefix_sum_down(__global unsigned int* as, const unsigned int n, const unsigned int step, const unsigned int workSize) {
+    const uint gid = get_global_id(0);
+
+    if (gid >= workSize) {
+        return;
+    }
+
+    if (step * (gid + 1) + step / 2 - 1 >= n) {
+        return;
+    }
+    
+    as[step * (gid + 1) + step / 2 - 1] += as[step * (gid + 1) - 1];
+}

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -58,17 +58,78 @@ int main(int argc, char **argv) {
 
     const std::vector<unsigned int> cpu_reference = computeCPU(as);
 
-    // remove me
-    return 0;
-
     {
+        ocl::Kernel write_zeros(radix_kernel, radix_kernel_length, "write_zeros");
+        write_zeros.compile();
+
+        ocl::Kernel radix_count(radix_kernel, radix_kernel_length, "radix_count");
+        radix_count.compile();
+
+        ocl::Kernel radix_sort(radix_kernel, radix_kernel_length, "radix_sort");
+        radix_sort.compile();
+
+        ocl::Kernel matrix_transpose(radix_kernel, radix_kernel_length, "matrix_transpose");
+        matrix_transpose.compile();
+
+        ocl::Kernel prefix_sum_up(radix_kernel, radix_kernel_length, "prefix_sum_up");
+        prefix_sum_up.compile();
+
+        ocl::Kernel prefix_sum_down(radix_kernel, radix_kernel_length, "prefix_sum_down");
+        prefix_sum_down.compile();
+
+        const unsigned int workSize = n;
+        const unsigned int workGroupSize = 128;
+        const unsigned int nbits = 4;
+        const unsigned int countersX = (1 << nbits);
+        const unsigned int countersY = (n + workGroupSize - 1) / workGroupSize;
+        const unsigned int countersSize = countersX * countersY;
+
+        gpu::gpu_mem_32u as_gpu, bs_gpu, counters_gpu, counters_transposed_gpu;
+        as_gpu.resizeN(n);
+        bs_gpu.resizeN(n);
+        counters_gpu.resizeN(countersSize);
+        counters_transposed_gpu.resizeN(countersSize);
+        
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            as_gpu.writeN(as.data(), n);
             // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+            t.restart();
 
-            // TODO
+            for (unsigned int bit_shift = 0; bit_shift < 32; bit_shift += nbits) {
+                write_zeros.exec(gpu::WorkSize(workGroupSize, countersSize), counters_gpu);
+
+                radix_count.exec(gpu::WorkSize(workGroupSize, n), as_gpu, counters_gpu, bit_shift);
+
+
+                matrix_transpose.exec(gpu::WorkSize(16, 16, countersX, countersY), counters_gpu,
+                                      counters_transposed_gpu, countersX, countersY);
+
+                {
+                    unsigned int step = 1;
+                    for (; step < countersSize; step *= 2) {
+                        const unsigned int workSize = countersSize / (step * 2);
+                        prefix_sum_up.exec(gpu::WorkSize(256, workSize), counters_transposed_gpu, countersSize, step,
+                                           workSize);
+                    }
+
+                    for (step /= 2; step > 1; step /= 2) {
+                        const unsigned int workSize = countersSize / step;
+                        prefix_sum_down.exec(gpu::WorkSize(256, workSize), counters_transposed_gpu, countersSize, step,
+                                             workSize);
+                    }
+                }
+
+                radix_sort.exec(gpu::WorkSize(workGroupSize, n), as_gpu, bs_gpu, counters_transposed_gpu, bit_shift);
+
+                as_gpu.swap(bs_gpu);
+            }
+
+            t.nextLap();
         }
         t.stop();
+
+        as_gpu.readN(as.data(), n);
 
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;


### PR DESCRIPTION
<details><summary>Локальный вывод </summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800X 8-Core Processor             . Intel(R) Corporation. Total memory: 32670 Mb
  Device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Using device #1: GPU. NVIDIA GeForce RTX 4080. Total memory: 16375 Mb
Data generated for n=33554432!
CPU: 11.6637+-0 s
CPU: 2.82929 millions/s
GPU: 0.0202073+-0.000389051 s
GPU: 1660.51 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 2.73846+-0 s
CPU: 12.0506 millions/s
GPU: 2.01284+-0.000982098 s
GPU: 16.6702 millions/s
</pre>

</p></details>

На `n=32 * 1024 * 1024` у меня radix sort отработал примерно так же, как и merge sort (там получилось `1690.6 millions/s`). Дополнительно запустил при `n=32 * 1024 * 1024 * 2` - вот тут уже у radix sort выигрыш - `2132.58 millions/s` против `1659.93 millions/s` у merge sort.