### PR TITLE
Task07 Григорий Рыбчиц ИТМО

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,19 @@
-// TODO
+__kernel void naive_prefix_sum(
+    __global const unsigned int *prev,
+    __global unsigned int *curr,
+    unsigned int k,
+    unsigned int n
+) {
+    int gid = get_global_id(0);
+
+    if (gid >= n) {
+        return;
+    }
+
+    if (gid < k) {
+        curr[gid] = prev[gid];
+
+    } else {
+        curr[gid] = prev[gid] + prev[gid - k];
+    }
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,10 +1,10 @@
 __kernel void naive_prefix_sum(
     __global const unsigned int *prev,
     __global unsigned int *curr,
-    unsigned int k,
-    unsigned int n
+    const unsigned int k,
+    const unsigned int n
 ) {
-    int gid = get_global_id(0);
+    const unsigned int gid = get_global_id(0);
 
     if (gid >= n) {
         return;
@@ -15,5 +15,35 @@ __kernel void naive_prefix_sum(
 
     } else {
         curr[gid] = prev[gid] + prev[gid - k];
+    }
+}
+
+__kernel void prefix_sum_up_sweep(
+    __global unsigned int *array, 
+    const unsigned int chunk_size, 
+    const unsigned int n
+) {
+    const unsigned int gid = get_global_id(0);
+
+    const unsigned int src = gid * chunk_size + chunk_size / 2 - 1;
+    const unsigned int dst = (gid + 1) * chunk_size - 1;
+
+    if (n > dst) {
+        array[dst] += array[src];
+    }
+}
+
+__kernel void prefix_sum_down_sweep(
+    __global unsigned int *array, 
+    const unsigned int chunk_size, 
+    const unsigned int n
+) {
+    int gid = get_global_id(0);
+
+    const unsigned int src = (gid + 1) * chunk_size - 1;
+    const unsigned int dst = (gid + 1) * chunk_size + chunk_size / 2 - 1;
+
+    if (n > dst) {
+        array[dst] += array[src];
     }
 }


### PR DESCRIPTION
<details>
<summary>local logs</summary>

```______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.8e-05+-2.27374e-13 s
CPU: 227.556 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU [naive]: 0.00237+-0.000227158 s
GPU [naive]: 1.72827 millions/s
GPU [work-efficient]: 0.004268+-0.000164765 s
GPU [work-efficient]: 0.9597 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 7.1e-05+-0 s
CPU: 230.761 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU [naive]: 0.00244283+-0.000135643 s
GPU [naive]: 6.70697 millions/s
GPU [work-efficient]: 0.00475317+-5.5601e-05 s
GPU [work-efficient]: 3.44697 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000290833+-5.63964e-06 s
CPU: 225.339 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU [naive]: 0.0028325+-0.00010231 s
GPU [naive]: 23.1372 millions/s
GPU [work-efficient]: 0.005266+-0.000166266 s
GPU [work-efficient]: 12.4451 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0011625+-1.12657e-05 s
CPU: 225.5 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU [naive]: 0.003403+-0.000365246 s
GPU [naive]: 77.0332 millions/s
GPU [work-efficient]: 0.00601667+-0.000131671 s
GPU [work-efficient]: 43.5696 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0047005+-4.19792e-05 s
CPU: 223.078 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU [naive]: 0.00436367+-0.000472007 s
GPU [naive]: 240.297 millions/s
GPU [work-efficient]: 0.0083105+-0.00040757 s
GPU [work-efficient]: 126.175 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0185323+-2.80337e-05 s
CPU: 226.324 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU [naive]: 0.00834217+-0.000269809 s
GPU [naive]: 502.784 millions/s
GPU [work-efficient]: 0.00987117+-0.000166222 s
GPU [work-efficient]: 424.905 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.074347+-0.000452152 s
CPU: 225.661 millions/s
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
GPU [naive]: 0.0236628+-0.000188366 s
GPU [naive]: 709.011 millions/s
GPU [work-efficient]: 0.0178947+-0.000155355 s
GPU [work-efficient]: 937.554 millions/s
```
</details>