### PR TITLE
Task01 Александр Белаш SPbU

### DIFF
--- a/src/cl/aplusb.cl
+++ b/src/cl/aplusb.cl
@@ -11,10 +11,22 @@
 // - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
 // - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)
 
-__kernel void aplusb(...) {
+__kernel void aplusb(
+    __global const float * a,
+    __global const float * b,
+    __global float * c,
+    unsigned int n
+) {
     // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
     // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
     // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
+
+    const size_t index = get_global_id(0);
+
+    if (index >= n)
+        return;
+
+    printf("index: %d", index);
 
     // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
     // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)

--- a/src/cl/aplusb.cl
+++ b/src/cl/aplusb.cl
@@ -12,22 +12,18 @@
 // - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)
 
 __kernel void aplusb(
-    __global const float * a,
-    __global const float * b,
+    __global float * a,
+    __global float * b,
     __global float * c,
     unsigned int n
 ) {
     // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
     // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
     // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
+    size_t index = get_global_id(0);
 
-    const size_t index = get_global_id(0);
-
-    if (index >= n)
-        return;
-
-    printf("index: %d", index);
-
+    if (index < n)
+        c[index] = a[index] + b[index];
     // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
     // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)
     // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,9 @@ int main() {
         if (kernel_sources.size() == 0) {
             throw std::runtime_error("Empty source file! May be you forgot to configure working directory properly?");
         }
-        // std::cout << kernel_sources << std::endl;
+        std::cout << "============ KERNEL ============" << std::endl;
+        std::cout << kernel_sources << std::endl;
+        std::cout << "================================" << std::endl;
     }
 
     { // Get platform

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,148 +37,122 @@ int main() {
     if (!ocl_init())
         throw std::runtime_error("Can't init OpenCL driver!");
 
-    // TODO 1 По аналогии с предыдущим заданием узнайте, какие есть устройства, и выберите из них какое-нибудь
-    // (если в списке устройств есть хоть одна видеокарта - выберите ее, если нету - выбирайте процессор)
-
-    cl_uint num_platforms;
-    OCL_SAFE_CALL(clGetPlatformIDs(0, nullptr, &num_platforms));
-    std::vector<cl_platform_id> platforms(num_platforms);
-    OCL_SAFE_CALL(clGetPlatformIDs(num_platforms, platforms.data(), nullptr));
-    cl_platform_id platform = platforms.at(0);
-
-    size_t platformNameSize;
-    OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, 0, nullptr, &platformNameSize));
-    std::vector<char> platformName(platformNameSize);
-    OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), nullptr));
-    std::cout << "Platform name: " << platformName.data() << std::endl;
-
-    cl_uint devicesSize;
-    OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_DEFAULT, 0, nullptr, &devicesSize));
-    std::vector<cl_device_id> devices(devicesSize);
-    OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_DEFAULT, devicesSize, devices.data(), nullptr));
-    std::cout << "Default devices amount: " << devicesSize << std::endl;
-
-    cl_device_id device = devices.at(0);
-
-
-    // TODO 2 Создайте контекст с выбранным устройством
-    // См. документацию https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/ -> OpenCL Runtime -> Contexts -> clCreateContext
-    // Не забывайте проверять все возвращаемые коды на успешность (обратите внимание, что в данном случае метод возвращает
-    // код по переданному аргументом errcode_ret указателю)
-    cl_context_properties properties[] = {
-        CL_CONTEXT_PLATFORM, (cl_context_properties) platform,
-        0
-    };
-
-    cl_int errcode_ret;
-    cl_context context = clCreateContext(properties, 1, &device, nullptr, nullptr, &errcode_ret);
-    OCL_SAFE_CALL(errcode_ret);
-    std::cout << "Made context" << std::endl;
-
-    // Контекст и все остальные ресурсы следует освобождать с помощью clReleaseContext/clReleaseQueue/clReleaseMemObject... (да, не очень RAII, но это лишь пример)
-
-    // TODO 3 Создайте очередь выполняемых команд в рамках выбранного контекста и устройства
-    // См. документацию https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/ -> OpenCL Runtime -> Runtime APIs -> Command Queues -> clCreateCommandQueue
-    // Убедитесь, что в соответствии с документацией вы создали in-order очередь задач
-
-    cl_int commandQueueError;
-    cl_command_queue commandQueue = clCreateCommandQueue(context, device, 0, &commandQueueError);
-    OCL_SAFE_CALL(commandQueueError);
-    std::cout << "Created command queue" << std::endl;
-
-    unsigned int n = 1000 * 1000;
-    // Создаем два массива псевдослучайных данных для сложения и массив для будущего хранения результата
-    std::vector<float> as(n, 0);
-    std::vector<float> bs(n, 0);
-    std::vector<float> cs(n, 0);
-    FastRandom r(n);
-    for (unsigned int i = 0; i < n; ++i) {
-        as[i] = r.nextf();
-        bs[i] = r.nextf();
-    }
-    std::cout << "Data generated for n=" << n << "!" << std::endl;
-
-    // TODO 4 Создайте три буфера в памяти устройства (в случае видеокарты - в видеопамяти - VRAM) - для двух суммируемых массивов as и bs (они read-only) и для массива с результатом cs (он write-only)
-    // См. Buffer Objects -> clCreateBuffer
-    // Размер в байтах соответственно можно вычислить через sizeof(float)=4 и тот факт, что чисел в каждом массиве n штук
-    // Данные в as и bs можно прогрузить этим же методом, скопировав данные из host_ptr=as.data() (и не забыв про битовый флаг, на это указывающий)
-    // или же через метод Buffer Objects -> clEnqueueWriteBuffer
-    cl_int as_buffer_error;
-    cl_mem as_buffer = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, n * sizeof(float), as.data(), &as_buffer_error);
-    OCL_SAFE_CALL(as_buffer_error);
-    std::cout << "Created buffer as" << std::endl;
-    cl_int bs_buffer_error;
-    cl_mem bs_buffer = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR, n * sizeof(float), bs.data(), &bs_buffer_error);
-    OCL_SAFE_CALL(as_buffer_error);
-    std::cout << "Created buffer bs" << std::endl;
-    cl_int cs_buffer_error;
-    cl_mem cs_buffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR, n * sizeof(float), cs.data(), &cs_buffer_error);
-    OCL_SAFE_CALL(cs_buffer_error);
-    std::cout << "Created buffer cs" << std::endl;
-
-    // TODO 6 Выполните TODO 5 (реализуйте кернел в src/cl/aplusb.cl)
-    // затем убедитесь, что выходит загрузить его с диска (убедитесь что Working directory выставлена правильно - см. описание задания),
-    // напечатав исходники в консоль (if проверяет, что удалось считать хоть что-то)
+    unsigned int n;
+    std::vector<float> as;
+    std::vector<float> bs;
+    std::vector<float> cs;
     std::string kernel_sources;
-    {
+
+    cl_platform_id platform;
+    cl_device_id device;
+    cl_context context;
+    cl_command_queue commandQueue;
+    cl_mem as_buffer;
+    cl_mem bs_buffer;
+    cl_mem cs_buffer;
+    cl_program program;
+    cl_kernel kernel;
+
+    { // Создаем два массива псевдослучайных данных для сложения и массив для будущего хранения результата
+        n = 100 * 1000 * 1000;
+        as = std::vector<float>(n, 0);
+        bs = std::vector<float>(n, 0);
+        cs = std::vector<float>(n, 0);
+        FastRandom r(n);
+        for (unsigned int i = 0; i < n; ++i) {
+            as[i] = r.nextf();
+            bs[i] = r.nextf();
+        }
+        std::cout << "Data generated for n=" << n << "!" << std::endl;
+    }
+
+    { // Prepare kernel source
         std::ifstream file("src/cl/aplusb.cl");
         kernel_sources = std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
         if (kernel_sources.size() == 0) {
             throw std::runtime_error("Empty source file! May be you forgot to configure working directory properly?");
         }
-        std::cout << kernel_sources << std::endl;
+        // std::cout << kernel_sources << std::endl;
     }
 
-    // TODO 7 Создайте OpenCL-подпрограмму с исходниками кернела
-    // см. Runtime APIs -> Program Objects -> clCreateProgramWithSource
-    // у string есть метод c_str(), но обратите внимание, что передать вам нужно указатель на указатель
-    cl_int createProgramError;
-    const char *strings[] = { kernel_sources.c_str() };
-    size_t lengths[] = { kernel_sources.length() };
-    cl_program program = clCreateProgramWithSource(context, 1, strings, lengths, &createProgramError);
-    OCL_SAFE_CALL(createProgramError);
+    { // Get platform
+        cl_uint num_platforms;
+        OCL_SAFE_CALL(clGetPlatformIDs(0, nullptr, &num_platforms));
+        std::vector<cl_platform_id> platforms(num_platforms);
+        OCL_SAFE_CALL(clGetPlatformIDs(num_platforms, platforms.data(), nullptr));
+        platform = platforms.at(0);
+    }
 
-    std::cout << "Created program" << std::endl;
+    { // Get device
+        cl_uint devicesSize;
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_DEFAULT, 0, nullptr, &devicesSize));
+        std::vector<cl_device_id> devices(devicesSize);
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_DEFAULT, devicesSize, devices.data(), nullptr));
+        device = devices.at(0);
+    }
 
-    // TODO 8 Теперь скомпилируйте программу и напечатайте в консоль лог компиляции
-    // см. clBuildProgram
-    OCL_SAFE_CALL(clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr));
-    std::cout << "Builded program" << std::endl;
+    { // Create context
+        cl_context_properties properties[] = { CL_CONTEXT_PLATFORM, (cl_context_properties) platform, 0 };
+        cl_int errcode_ret;
+        context = clCreateContext(properties, 1, &device, nullptr, nullptr, &errcode_ret);
+        OCL_SAFE_CALL(errcode_ret);
+    }
 
-    // А также напечатайте лог компиляции (он будет очень полезен, если в кернеле есть синтаксические ошибки - т.е. когда clBuildProgram вернет CL_BUILD_PROGRAM_FAILURE)
-    // Обратите внимание, что при компиляции на процессоре через Intel OpenCL драйвер - в логе указывается, какой ширины векторизацию получилось выполнить для кернела
-    // см. clGetProgramBuildInfo
-    //    size_t log_size = 0;
-    //    std::vector<char> log(log_size, 0);
-    //    if (log_size > 1) {
-    //        std::cout << "Log:" << std::endl;
-    //        std::cout << log.data() << std::endl;
-    //    }
+    { // Create command queue
+        cl_int commandQueueError;
+        commandQueue = clCreateCommandQueue(context, device, 0, &commandQueueError);
+        OCL_SAFE_CALL(commandQueueError);
+    }
 
-    size_t buildLogSize;
-    OCL_SAFE_CALL(clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, nullptr, &buildLogSize));
-    std::vector<char> buildLog(buildLogSize);
-    OCL_SAFE_CALL(clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, buildLogSize, buildLog.data(), nullptr));
-    std::cout << "=== Build Log: ===" << std::endl;
-    std::cout << buildLog.data() << std::endl;
+    { // Create program
+        cl_int error;
+        const char *strings[] = { kernel_sources.c_str() };
+        size_t lengths[] = { kernel_sources.length() };
+        program = clCreateProgramWithSource(context, 1, strings, nullptr, &error);
+        OCL_SAFE_CALL(error);
+        error = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
 
-    // TODO 9 Создайте OpenCL-kernel в созданной подпрограмме (в одной подпрограмме может быть несколько кернелов, но в данном случае кернел один)
-    // см. подходящую функцию в Runtime APIs -> Program Objects -> Kernel Objects
+        if (error != CL_SUCCESS) {
+            std::cout << "Error building program" << std::endl;
 
-    cl_int kernelCreateError;
-    cl_kernel kernel = clCreateKernel(program, "aplusb", &kernelCreateError);
-    OCL_SAFE_CALL(kernelCreateError);
-    std::cout << "Created kernel" << std::endl;
+            size_t buildLogSize;
+            OCL_SAFE_CALL(clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, nullptr, &buildLogSize));
+            std::vector<char> buildLog(buildLogSize);
+            OCL_SAFE_CALL(clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, buildLogSize, buildLog.data(), nullptr));
+            std::cout << "=== Build Log: ===" << std::endl;
+            std::cout << buildLog.data() << std::endl;
+            OCL_SAFE_CALL(error);
+        }
+    }
 
-    // TODO 10 Выставите все аргументы в кернеле через clSetKernelArg (as_gpu, bs_gpu, cs_gpu и число значений, убедитесь, что тип количества элементов такой же в кернеле)
-    OCL_SAFE_CALL(clSetKernelArg(kernel, 0, sizeof(float) * n, &as_buffer));
-    OCL_SAFE_CALL(clSetKernelArg(kernel, 1, sizeof(float) * n, &bs_buffer));
-    OCL_SAFE_CALL(clSetKernelArg(kernel, 2, sizeof(float) * n, &cs_buffer));
-    OCL_SAFE_CALL(clSetKernelArg(kernel, 3, sizeof(unsigned int), &n));
+    { // Create kernel
+        cl_int error;
+        kernel = clCreateKernel(program, "aplusb", &error);
+        OCL_SAFE_CALL(error);
+    }
 
-    std::cout << "Set kernel args" << std::endl;
+    { // Create buffers
+        cl_int error;
 
-    // TODO 11 Выше увеличьте n с 1000*1000 до 100*1000*1000 (чтобы дальнейшие замеры были ближе к реальности)
+        as_buffer = clCreateBuffer(context, CL_MEM_READ_ONLY, n * sizeof(float), nullptr, &error);
+        OCL_SAFE_CALL(error);
+        bs_buffer = clCreateBuffer(context, CL_MEM_READ_ONLY, n * sizeof(float), nullptr, &error);
+        OCL_SAFE_CALL(error);
+        cs_buffer = clCreateBuffer(context, CL_MEM_WRITE_ONLY, n * sizeof(float), nullptr, &error);
+        OCL_SAFE_CALL(error);
+
+        error = clEnqueueWriteBuffer(commandQueue, as_buffer, CL_TRUE, 0, sizeof(float) * n, as.data(), 0, NULL, NULL);
+        OCL_SAFE_CALL(error);
+        error = clEnqueueWriteBuffer(commandQueue, bs_buffer, CL_TRUE, 0, sizeof(float) * n, bs.data(), 0, NULL, NULL);
+        OCL_SAFE_CALL(error);
+    }
+
+    { // Set up all args
+        OCL_SAFE_CALL(clSetKernelArg(kernel, 0, sizeof(cl_mem), &as_buffer));
+        OCL_SAFE_CALL(clSetKernelArg(kernel, 1, sizeof(cl_mem), &bs_buffer));
+        OCL_SAFE_CALL(clSetKernelArg(kernel, 2, sizeof(cl_mem), &cs_buffer));
+        OCL_SAFE_CALL(clSetKernelArg(kernel, 3, sizeof(unsigned int), &n));
+    }
 
     // TODO 12 Запустите выполнения кернела:
     // - С одномерной рабочей группой размера 128
@@ -192,8 +166,11 @@ int main() {
         size_t global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
         timer t;// Это вспомогательный секундомер, он замеряет время своего создания и позволяет усреднять время нескольких замеров
         for (unsigned int i = 0; i < 20; ++i) {
-            // clEnqueueNDRangeKernel...
-            // clWaitForEvents...
+            size_t global = (n + 127) / 128 * 128;
+            size_t local = 128;
+            cl_event event;
+            OCL_SAFE_CALL(clEnqueueNDRangeKernel(commandQueue, kernel, 1, nullptr, &global, &local, 0, nullptr, &event));
+            OCL_SAFE_CALL(clWaitForEvents(1, &event));
             t.nextLap();// При вызове nextLap секундомер запоминает текущий замер (текущий круг) и начинает замерять время следующего круга
         }
         // Среднее время круга (вычисления кернела) на самом деле считается не по всем замерам, а лишь с 20%-перцентайля по 80%-перцентайль (как и стандартное отклонение)
@@ -207,7 +184,7 @@ int main() {
         // - Флопс - это число операций с плавающей точкой в секунду
         // - В гигафлопсе 10^9 флопсов
         // - Среднее время выполнения кернела равно t.lapAvg() секунд
-        std::cout << "GFlops: " << 0 << std::endl;
+        std::cout << "GFlops: " << (float) n / 1e9 / t.lapAvg() << std::endl;
 
         // TODO 14 Рассчитайте используемую пропускную способность обращений к видеопамяти (в гигабайтах в секунду)
         // - Всего элементов в массивах по n штук
@@ -215,26 +192,27 @@ int main() {
         // - Обращений к видеопамяти 2*n*sizeof(float) байт на чтение и 1*n*sizeof(float) байт на запись, т.е. итого 3*n*sizeof(float) байт
         // - В гигабайте 1024*1024*1024 байт
         // - Среднее время выполнения кернела равно t.lapAvg() секунд
-        std::cout << "VRAM bandwidth: " << 0 << " GB/s" << std::endl;
+        std::cout << "VRAM bandwidth: " << (float) (3 * n * sizeof(float)) / t.lapAvg() / (1024*1024*1024) << " GB/s" << std::endl;
     }
 
-    // TODO 15 Скачайте результаты вычислений из видеопамяти (VRAM) в оперативную память (RAM) - из cs_gpu в cs (и рассчитайте скорость трансфера данных в гигабайтах в секунду)
     {
         timer t;
         for (unsigned int i = 0; i < 20; ++i) {
-            // clEnqueueReadBuffer...
+            clEnqueueReadBuffer(commandQueue, cs_buffer, CL_TRUE, 0, n * sizeof(float), cs.data(), 0, NULL, NULL);
             t.nextLap();
         }
         std::cout << "Result data transfer time: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "VRAM -> RAM bandwidth: " << 0 << " GB/s" << std::endl;
+        std::cout << "VRAM -> RAM bandwidth: " << (float) (n * sizeof(float)) / t.lapAvg() / (1024*1024*1024) << " GB/s" << std::endl;
     }
 
     // TODO 16 Сверьте результаты вычислений со сложением чисел на процессоре (и убедитесь, что если в кернеле сделать намеренную ошибку, то эта проверка поймает ошибку)
-    //    for (unsigned int i = 0; i < n; ++i) {
-    //        if (cs[i] != as[i] + bs[i]) {
-    //            throw std::runtime_error("CPU and GPU results differ!");
-    //        }
-    //    }
+    {
+        for (unsigned int i = 0; i < n; ++i) {
+           if (cs[i] != as[i] + bs[i]) {
+               throw std::runtime_error("CPU and GPU results differ!");
+           }
+       }
+    }
 
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./build/aplusb
Data generated for n=100000000!
============ KERNEL ============
#ifdef __CLION_IDE__
    // Этот include виден только для CLion парсера, это позволяет IDE "знать" ключевые слова вроде __kernel, __global
    // а также уметь подсказывать OpenCL методы, описанные в данном инклюде (такие как get_global_id(...) и get_local_id(...))
    #include "clion_defines.cl"
#endif

#line 8// Седьмая строчка теперь восьмая (при ошибках компиляции в логе компиляции будут указаны корректные строчки благодаря этой директиве)

// TODO 5 реализуйте кернел:
// - От обычной функции кернел отличается модификатором __kernel и тем, что возвращаемый тип всегда void
// - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
// - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)

__kernel void aplusb(
    __global float * a,
    __global float * b,
    __global float * c,
    unsigned int n
) {
    // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
    // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
    // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
    size_t index = get_global_id(0);

    if (index < n)
        c[index] = a[index] + b[index];
    // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
    // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)
    // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,
    // либо сделать return в кернеле до обращения к данным в тех WorkItems, где get_global_id(0) выходит за границы данных (явной проверкой)
}

================================
Kernel average time: 0.0684037+-0.000213492 s
GFlops: 1.46191
VRAM bandwidth: 16.3381 GB/s
Result data transfer time: 0.0910583+-0.00011432 s
VRAM -> RAM bandwidth: 4.09111 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./build/aplusb
Data generated for n=100000000!
============ KERNEL ============
#ifdef __CLION_IDE__
    // Этот include виден только для CLion парсера, это позволяет IDE "знать" ключевые слова вроде __kernel, __global
    // а также уметь подсказывать OpenCL методы, описанные в данном инклюде (такие как get_global_id(...) и get_local_id(...))
    #include "clion_defines.cl"
#endif

#line 8// Седьмая строчка теперь восьмая (при ошибках компиляции в логе компиляции будут указаны корректные строчки благодаря этой директиве)

// TODO 5 реализуйте кернел:
// - От обычной функции кернел отличается модификатором __kernel и тем, что возвращаемый тип всегда void
// - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
// - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)

__kernel void aplusb(
    __global float * a,
    __global float * b,
    __global float * c,
    unsigned int n
) {
    // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
    // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
    // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
    size_t index = get_global_id(0);

    if (index < n)
        c[index] = a[index] + b[index];
    // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
    // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)
    // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,
    // либо сделать return в кернеле до обращения к данным в тех WorkItems, где get_global_id(0) выходит за границы данных (явной проверкой)
}

================================
Kernel average time: 0.0351796+-0.00175755 s
GFlops: 2.84256
VRAM bandwidth: 31.7681 GB/s
Result data transfer time: 0.0192444+-0.000231689 s
VRAM -> RAM bandwidth: 19.3578 GB/s
</pre>

</p></details>