### PR TITLE
Task07 Степан Остапенко ITMO

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,10 @@
-// TODO
+__kernel void prefix_sum_kernel(__global int *a, __global int *b, unsigned int n, unsigned int start, int step, unsigned int offset) {
+    int pos = start + get_global_id(0) * step;
+    if (pos < 0 || pos >= n) {
+        return;
+    }
+    b[pos] = a[pos];
+    if (pos >= offset) {
+        b[pos] += a[pos - offset];
+    }
+}


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ build/prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 7837 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 4.21667e-05+-3.72678e-07 s
CPU: 97.1383 millions/s
GPU: 0.0002825+-9.10586e-06 s
GPU: 14.4991 millions/s
GPU [work-efficient]: 0.000370333+-6.47216e-06 s
GPU [work-efficient]: 11.0603 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000179667+-2.86744e-06 s
CPU: 91.1911 millions/s
GPU: 0.000759667+-0.000104834 s
GPU: 21.5674 millions/s
GPU [work-efficient]: 0.0004935+-8.15986e-06 s
GPU [work-efficient]: 33.1996 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000777+-2.44336e-05 s
CPU: 84.3449 millions/s
GPU: 0.00133383+-1.97012e-05 s
GPU: 49.1336 millions/s
GPU [work-efficient]: 0.000746+-6.45626e-05 s
GPU [work-efficient]: 87.8499 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00324267+-0.000252092 s
CPU: 80.8421 millions/s
GPU: 0.00519117+-0.0010001 s
GPU: 50.4981 millions/s
GPU [work-efficient]: 0.001457+-2.90918e-05 s
GPU [work-efficient]: 179.92 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0116173+-0.000332561 s
CPU: 90.2596 millions/s
GPU: 0.0218777+-0.00214867 s
GPU: 47.9291 millions/s
GPU [work-efficient]: 0.00640867+-8.9235e-05 s
GPU [work-efficient]: 163.618 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0475867+-0.00103572 s
CPU: 88.1403 millions/s
GPU: 0.0961585+-0.00433568 s
GPU: 43.6187 millions/s
GPU [work-efficient]: 0.0328238+-0.00103636 s
GPU [work-efficient]: 127.782 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.187459+-0.00109043 s
CPU: 89.4983 millions/s
GPU: 0.431656+-0.0193294 s
GPU: 38.8671 millions/s
GPU [work-efficient]: 0.13493+-0.000927697 s
GPU [work-efficient]: 124.341 millions/s

</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.66667e-06+-7.45356e-07 s
CPU: 1536 millions/s
GPU: 0.000175167+-6.09417e-06 s
GPU: 23.3834 millions/s
GPU [work-efficient]: 0.000187667+-1.49071e-06 s
GPU [work-efficient]: 21.8259 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.66667e-05+-1.69967e-06 s
CPU: 983.04 millions/s
GPU: 0.000318333+-3.59011e-06 s
GPU: 51.4681 millions/s
GPU [work-efficient]: 0.000249333+-2.13437e-06 s
GPU [work-efficient]: 65.7112 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.13333e-05+-4.71405e-07 s
CPU: 1585.55 millions/s
GPU: 0.000842833+-1.95078e-06 s
GPU: 77.7568 millions/s
GPU [work-efficient]: 0.000386333+-6.84755e-06 s
GPU [work-efficient]: 169.636 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000161+-1.81899e-12 s
CPU: 1628.22 millions/s
GPU: 0.00284167+-1.38042e-05 s
GPU: 92.2501 millions/s
GPU [work-efficient]: 0.000790333+-9.86013e-06 s
GPU [work-efficient]: 331.688 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0006485+-1.11803e-06 s
CPU: 1616.93 millions/s
GPU: 0.0119732+-0.000117982 s
GPU: 87.5772 millions/s
GPU [work-efficient]: 0.002076+-4.97929e-05 s
GPU [work-efficient]: 505.094 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00457483+-3.74451e-05 s
CPU: 916.821 millions/s
GPU: 0.0551495+-4.47837e-05 s
GPU: 76.0533 millions/s
GPU [work-efficient]: 0.006039+-0.000110799 s
GPU [work-efficient]: 694.536 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0358498+-5.26733e-05 s
CPU: 467.986 millions/s
GPU: 0.226646+-0.00117342 s
GPU: 74.024 millions/s
GPU [work-efficient]: 0.0324458+-0.00213424 s
GPU [work-efficient]: 517.084 millions/s

</pre>

</p></details>

Почему-то обычная GPU-версия всегда проигрывает даже CPU-версии. Возможно, это из-за того, что все вычисления, на самом деле, производятся не на GPU.

Зато при локальном запуске work-efficient-версия работает быстрее всего.