### PR TITLE
Task07 Кудрявцев Федор HSE

### DIFF
--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,19 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void prefix_sum_binary(__global unsigned int* sum, unsigned int n, unsigned int rate)
+{
+       const int i = (get_global_id(0) + 1) * rate - 1;
+       if (i < n)
+            sum[i] += sum[i - rate / 2];
+}
+
+__kernel void prefix_sum_second_part(__global unsigned int* sum, unsigned int n, unsigned int rate)
+{
+    const int i = (get_global_id(0) + 1) * rate - 1 + rate / 2;
+    if (i < n)
+        sum[i] += sum[i - rate / 2];
+}

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -47,6 +47,12 @@ std::vector<unsigned int> computeCPU(const std::vector<unsigned int> &as)
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
 	for (unsigned int n = 4096; n <= max_n; n *= 4) {
 		std::cout << "______________________________________________" << std::endl;
 		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
@@ -83,17 +89,34 @@ int main(int argc, char **argv)
 #endif
 
 // work-efficient prefix sum
-#if 0
         {
             std::vector<unsigned int> res(n);
+            ocl::Kernel prefix_sum_binary(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_binary");
+            ocl::Kernel prefix_sum_second_part(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_second_part");
+            prefix_sum_binary.compile();
+            prefix_sum_second_part.compile();
+
+            gpu::gpu_mem_32u gpu;
+            gpu.resizeN(n);
 
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                // TODO
+                gpu.writeN(as.data(), as.size());
                 t.restart();
-                // TODO
+
+                for (unsigned int rate = 2; rate <= n; rate *= 2) {
+                    prefix_sum_binary.exec(gpu::WorkSize(64, n / rate), gpu, n, rate);
+
+                }
+
+                for (unsigned int rate = n / 2; rate >= 2; rate /= 2) {
+                    prefix_sum_second_part.exec(gpu::WorkSize(64, (n + rate - 1) / rate), gpu, n, rate);
+                }
+
                 t.nextLap();
             }
+
+            gpu.readN(res.data(), as.size());
 
             std::cout << "GPU [work-efficient]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
             std::cout << "GPU [work-efficient]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
@@ -102,6 +125,5 @@ int main(int argc, char **argv)
                 EXPECT_THE_SAME(cpu_reference[i], res[i], "GPU result should be consistent!");
             }
         }
-#endif
 	}
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 16003 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6401 Mb
Using device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 6401 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.9e-05+-2.23607e-06 s
CPU: 215.579 millions/s
GPU [work-efficient]: 0.00383917+-0.000189057 s
GPU [work-efficient]: 1.0669 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 7.33333e-05+-1.37437e-06 s
CPU: 223.418 millions/s
GPU [work-efficient]: 0.00472083+-0.000359624 s
GPU [work-efficient]: 3.47057 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000325833+-1.53885e-05 s
CPU: 201.134 millions/s
GPU [work-efficient]: 0.00316467+-0.000670527 s
GPU [work-efficient]: 20.7087 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00216483+-0.000101952 s
CPU: 121.092 millions/s
GPU [work-efficient]: 0.004723+-0.000942176 s
GPU [work-efficient]: 55.5037 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.004984+-0.000232738 s
CPU: 210.388 millions/s
GPU [work-efficient]: 0.00438167+-0.000272926 s
GPU [work-efficient]: 239.31 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.020307+-0.000391551 s
CPU: 206.545 millions/s
GPU [work-efficient]: 0.0121908+-0.000379541 s
GPU [work-efficient]: 344.054 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0924637+-0.00671588 s
CPU: 181.447 millions/s
GPU [work-efficient]: 0.0433753+-0.00289487 s
GPU [work-efficient]: 386.792 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC [7](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:8)763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 5.16667e-06+-3.7267[8](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:9)e-07 s
CPU: 792.774 millions/s
GPU [work-efficient]: 0.0001935+-1.70783e-06 s
GPU [work-efficient]: 21.168 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1e-05+-1.13687e-13 s
CPU: 1638.4 millions/s
GPU [work-efficient]: 0.000255+-1.41421e-06 s
GPU [work-efficient]: 64.251 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4e-05+-4.54747e-13 s
CPU: 1638.4 millions/s
GPU [work-efficient]: 0.0003885+-4.78714e-06 s
GPU [work-efficient]: 168.6[9](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:10) millions/s
______________________________________________
n=262144 values in range: [0; [10](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:11)23]
CPU: 0.000161333+-4.71405e-07 s
CPU: 1624.86 millions/s
GPU [work-efficient]: 0.000791833+-9.29904e-06 s
GPU [work-efficient]: 331.06 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000650333+-2.28522e-06 s
CPU: 1612.37 millions/s
GPU [work-efficient]: 0.00189017+-8.74708e-05 s
GPU [work-efficient]: 554.753 millions/s
______________________________________________
n=4194304 values in range: [0; 5[11](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:12)]
CPU: 0.002731+-4.16333e-06 s
CPU: 1535.81 millions/s
GPU [work-efficient]: 0.00521983+-0.000151619 s
GPU [work-efficient]: 803.532 millions/s
______________________________________________
n=16777216 values in range: [0; [12](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:13)7]
CPU: 0.0122873+-2.60938e-05 s
CPU: [13](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:14)65.41 millions/s
GPU [work-efficient]: 0.034299+-0.000332985 s
GPU [work-efficient]: 489.[14](https://github.com/koufesser/GPGPUTasks2024/actions/runs/12755237125/job/35550825028#step:7:15)6 millions/s
</pre>

</p></details>