### PR TITLE
Task04 Ilya Bolkisev ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -7,21 +7,79 @@
 
 // TILE_SIZE и WORK_PER_THREAD задаются через поле 'defines' в кернел конфиге
 
-__kernel void matrix_multiplication_naive()
+__kernel void matrix_multiplication_naive(__global const float *A, __global const float *B, __global float *C, const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    int row = get_global_id(0);
+    int col = get_global_id(1);
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k)
+        sum += A[row * K + k] * B[k * N + col];
+    C[row * N + col] = sum;
 }
 
 #ifdef TILE_SIZE
-__kernel void matrix_multiplication_local()
+__kernel void matrix_multiplication_local(__global const float *A, __global const float *B, __global float *C, const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    __local float Asub[TILE_SIZE][TILE_SIZE];
+    __local float Bsub[TILE_SIZE][TILE_SIZE];
+
+    int global_row = get_global_id(0);
+    int global_col = get_global_id(1);
+
+    int local_row = get_local_id(0);
+    int local_col = get_local_id(1);
+
+    float sum = 0.0f;
+
+    int num_tiles = (K + TILE_SIZE - 1) / TILE_SIZE;
+
+    for (int t = 0; t < num_tiles; ++t) {
+        Asub[local_row][local_col] = A[global_row * K + t * TILE_SIZE + local_col];
+        Bsub[local_row][local_col] = B[t * TILE_SIZE * N + local_row * N + global_col];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k)
+            sum += Asub[local_row][k] * Bsub[k][local_col];
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    C[global_row * N + global_col] = sum;
 }
 #endif
 
 #if defined(TILE_SIZE) && defined(WORK_PER_THREAD)
-__kernel void matrix_multiplication_local_wpt()
+__kernel void matrix_multiplication_local_wpt(__global float *A, __global float *B, __global float *C, const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    __local float Asub[TILE_SIZE][TILE_SIZE];
+    __local float Bsub[TILE_SIZE][TILE_SIZE];
+
+    int global_row = get_global_id(0);
+    int global_col = get_global_id(1);
+
+    int local_row = get_local_id(0);
+    int local_col = get_local_id(1);
+
+    float sum[WORK_PER_THREAD];
+    for (int w = 0; w < WORK_PER_THREAD; w++)
+        sum[w] = 0.0f;
+
+    int num_tiles = (K + TILE_SIZE - 1) / TILE_SIZE;
+
+    for (int t = 0; t < num_tiles; t++)
+    {
+        for (int w = 0; w < WORK_PER_THREAD; w++) {
+            Asub[local_col * WORK_PER_THREAD + w][local_row] = A[(global_col * WORK_PER_THREAD + w) * K + t * TILE_SIZE + local_row];
+            Bsub[local_col * WORK_PER_THREAD + w][local_row] = B[(t * TILE_SIZE + local_col * WORK_PER_THREAD + w) * N + global_row];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++)
+            for (int w = 0; w < WORK_PER_THREAD; w++)
+                sum[w] += Asub[local_col * WORK_PER_THREAD + w][k] * Bsub[k][local_row];
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_THREAD; w++) {
+        C[current_row * N + global_row] = sum[w];
 }
 #endif

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -79,7 +79,7 @@ __kernel void matrix_multiplication_local_wpt(__global float *A, __global float 
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 
-    for (int w = 0; w < WORK_PER_THREAD; w++) {
-        C[current_row * N + global_row] = sum[w];
+    for (int w = 0; w < WORK_PER_THREAD; w++)
+        C[(global_col * WORK_PER_THREAD + w) * N + global_row] = sum[w];
 }
 #endif

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -4,18 +4,54 @@
 
 
 #line 6
+#define TILE_SIZE 16
 
-__kernel void matrix_transpose_naive()
+__kernel void matrix_transpose_naive(__global float *A, __global float *B, const unsigned int M, const unsigned int K)
 {
-    // TODO
+    int row = get_global_id(0);
+    int col = get_global_id(1);
+
+    if (row < M && col < K) {
+        B[col * M + row] = A[row * K + col];
+    }
 }
 
-__kernel void matrix_transpose_local_bad_banks()
+
+__kernel void matrix_transpose_local_bad_banks(__global float *A, __global float *B, const unsigned int M, const unsigned int K)
 {
-    // TODO
+    int global_row = get_global_id(0);
+    int global_col = get_global_id(1);
+
+    int local_row = get_local_id(0);
+    int local_col = get_local_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    int tile_row = get_group_id(0);
+    int tile_col = get_group_id(1);
+
+    tile[local_col][local_row] = A[global_col * M + global_row];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    B[(tile_row * TILE_SIZE + local_col) * K + tile_col * TILE_SIZE + local_row] = tile[local_row][local_col];
 }
 
-__kernel void matrix_transpose_local_good_banks()
+
+__kernel void matrix_transpose_local_good_banks(__global float *A, __global float *B, const unsigned int M, const unsigned int K)
 {
-    // TODO
+    int global_row = get_global_id(0);
+    int global_col = get_global_id(1);
+
+    int local_row = get_local_id(0);
+    int local_col = get_local_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE+1];
+
+    int tile_row = get_group_id(0);
+    int tile_col = get_group_id(1);
+
+    tile[local_col][local_row] = A[global_col * M + global_row];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    B[(tile_row * TILE_SIZE + local_col) * K + tile_col * TILE_SIZE + local_row] = tile[local_row][local_col];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -50,9 +50,8 @@ struct KernelConfig {
 
 KernelConfig makeNaiveConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_naive";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(16, 16, M, K);
     std::string defines;
     std::string prefix = "[naive, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -60,9 +59,8 @@ KernelConfig makeNaiveConfig(unsigned int tile_size)
 
 KernelConfig makeLocalConfig(unsigned int tile_size)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size, M, K);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size);
     std::string prefix = "[local, ts=" + std::to_string(tile_size) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -70,9 +68,8 @@ KernelConfig makeLocalConfig(unsigned int tile_size)
 
 KernelConfig makeLocalWPTConfig(unsigned int tile_size, unsigned int wpt)
 {
-    throw std::runtime_error("not implemented");
     std::string kernel_name = "matrix_multiplication_local_wpt";
-    gpu::WorkSize work_size(0, 0/*TODO*/);
+    gpu::WorkSize work_size(tile_size, tile_size / wpt, M, K / wpt);
     std::string defines = "-DTILE_SIZE=" + std::to_string(tile_size) + " -DWORK_PER_THREAD=" + std::to_string(wpt);
     std::string prefix = "[local wpt, ts=" + std::to_string(tile_size) + ", wpt=" + std::to_string(wpt) + "]";
     return KernelConfig{kernel_name, work_size, defines, prefix};
@@ -142,9 +139,6 @@ int main(int argc, char **argv)
     std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
 
     const std::vector<float> cs_cpu_reference = computeCPU(as.data(), bs.data());
-
-    // TODO uncomment
-    return 0;
 
     runTest(makeNaiveConfig(4), as.data(), bs.data(), cs_cpu_reference.data());
     runTest(makeNaiveConfig(8), as.data(), bs.data(), cs_cpu_reference.data());

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -33,9 +33,8 @@ void runTest(const std::string &kernel_name, const float *as)
         // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
         // - для 1D, 2D и 3D рабочего пространства соответственно
 
-        // TODO uncomment
-//        gpu::WorkSize work_size(0, 0, 0, 0 /*TODO*/);
-//        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
+        gpu::WorkSize work_size(16, 16, M, K);
+        matrix_transpose_kernel.exec(work_size, as_gpu, as_t_gpu, M, K);
 
         t.nextLap();
     }
@@ -74,8 +73,6 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    // TODO uncomment
-    return 0;
 
     runTest("matrix_transpose_naive", as.data());
     runTest("matrix_transpose_local_bad_banks", as.data());


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
<pre>
<details><summary>Транспонирование матрицы</summary><p>
<pre>
/home/realist/CLionProjects/GPGPUTasks2024/cmake-build-debug/matrix_transpose 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz. Intel(R) Corporation. Total memory: 32028 Mb
  Device #1: GPU. NVIDIA GeForce RTX 2070 SUPER. Total memory: 7973 Mb
Using device #1: GPU. NVIDIA GeForce RTX 2070 SUPER. Total memory: 7973 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.000434083+-1.8375e-06 s
    GPU: 38649.8 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.000403917+-9.53794e-07 s
    GPU: 41536.3 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.000368717+-1.87165e-06 s
    GPU: 45501.6 millions/s
</pre>
</p></details>
<details><summary>Умножение матриц</summary><p>
<pre>
/home/realist/CLionProjects/GPGPUTasks2024/cmake-build-debug/matrix_multiplication 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz. Intel(R) Corporation. Total memory: 32028 Mb
  Device #1: GPU. NVIDIA GeForce RTX 2070 SUPER. Total memory: 7973 Mb
Using device #1: GPU. NVIDIA GeForce RTX 2070 SUPER. Total memory: 7973 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.10487+-0 s
CPU: 0.644149 GFlops
[naive, ts=4]
    GPU: 0.0167945+-0.00143547 s
    GPU: 119.087 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.0145427+-1.67299e-05 s
    GPU: 137.526 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.0151805+-0.000773203 s
    GPU: 131.748 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.010126+-6.97615e-06 s
    GPU: 197.511 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.00644183+-0.000255569 s
    GPU: 310.471 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.00737667+-4.88763e-06 s
    GPU: 271.125 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.0123448+-0.000834888 s
    GPU: 162.011 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.0140702+-5.047e-06 s
    GPU: 142.145 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.00261633+-1.37437e-06 s
    GPU: 764.429 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.00347033+-6.99206e-06 s
    GPU: 576.314 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.0044315+-0.000124166 s
    GPU: 451.314 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.00141967+-4.71405e-07 s
    GPU: 1408.78 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.00131133+-0.000138899 s
    GPU: 1525.17 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.00106083+-1.06719e-06 s
    GPU: 1885.31 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.00131717+-0.000154228 s
    GPU: 1518.41 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>
</pre>
</p></details>
 Транспонирование:
 Здесь все вполне ожидаемо, транспонирование с коалесным доступом выигрывает по скорости, и транспонирование без банк-конфликтов выигрывает по скорости у транспонирования с конфликтами.
 Умножение:
Здесь все получилось по интереснее, правильно подобранный wpt позволяет ускорить работу алгоритма более чем в 5 раз. Ну и наивный прогноз сильно проигрывает остальным, даже простое умножение через локальную память отработало  в 2 раза быстрее.
<details><summary>Вывод Github CI</summary><p>
<pre>
<details><summary>Транспонирование матрицы</summary><p>
<pre>
Run ./matrix_transpose
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=4096, K=4096
[matrix_transpose_naive]
    GPU: 0.0162182+-0.00122459 s
    GPU: 1034.47 millions/s
[matrix_transpose_local_bad_banks]
    GPU: 0.0129802+-0.000253487 s
    GPU: 1292.52 millions/s
[matrix_transpose_local_good_banks]
    GPU: 0.0129295+-0.000169476 s
    GPU: 1297.6 millions/s
</pre>
</p></details>
<details><summary>Умножение матриц</summary><p>
<pre>
Run ./matrix_multiplication
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.03505+-0 s
CPU: 0.331398 GFlops
[naive, ts=4]
    GPU: 0.343734+-0.0063283 s
    GPU: 5.81845 GFlops
    Average difference: 0.000149043%
[naive, ts=8]
    GPU: 0.346045+-0.0116812 s
    GPU: 5.7796 GFlops
    Average difference: 0.000149043%
[naive, ts=16]
    GPU: 0.344591+-0.00551645 s
    GPU: 5.80399 GFlops
    Average difference: 0.000149043%
[local, ts=4]
    GPU: 0.51702+-0.00234683 s
    GPU: 3.86832 GFlops
    Average difference: 0.000149043%
[local, ts=8]
    GPU: 0.300849+-0.00350287 s
    GPU: 6.64786 GFlops
    Average difference: 0.000149043%
[local, ts=16]
    GPU: 0.277918+-0.00255755 s
    GPU: 7.19637 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=2]
    GPU: 0.48763+-0.00344136 s
    GPU: 4.10147 GFlops
    Average difference: 0.000149043%
[local wpt, ts=4, wpt=4]
    GPU: 0.412046+-0.00429149 s
    GPU: 4.85382 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=2]
    GPU: 0.12222+-0.00189532 s
    GPU: 16.364 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=4]
    GPU: 0.136034+-0.00185375 s
    GPU: 14.7022 GFlops
    Average difference: 0.000149043%
[local wpt, ts=8, wpt=8]
    GPU: 0.131871+-0.00179952 s
    GPU: 15.1663 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=2]
    GPU: 0.0742587+-0.000816439 s
    GPU: 26.9329 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=4]
    GPU: 0.0761208+-0.0006123 s
    GPU: 26.274 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=8]
    GPU: 0.078306+-0.00130726 s
    GPU: 25.5408 GFlops
    Average difference: 0.000149043%
[local wpt, ts=16, wpt=16]
    GPU: 0.0888135+-0.000905724 s
    GPU: 22.5191 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>
</pre>
</p></details>