### PR TITLE
Task00 Алина Крылова SPbU

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,9 @@ int main() {
         // Попробуйте вместо CL_PLATFORM_NAME передать какое-нибудь случайное число - например 239
         // Т.к. это некорректный идентификатор параметра платформы - то метод вернет код ошибки
         // Макрос OCL_SAFE_CALL заметит это, и кинет ошибку с кодом
+
+        // OCL_SAFE_CALL(clGetPlatformInfo(platform, 239, 0, nullptr, &platformNameSize));
+
         // Откройте таблицу с кодами ошибок:
         // libs/clew/CL/cl.h:103
         // P.S. Быстрый переход к файлу в CLion: Ctrl+Shift+N -> cl.h (или даже с номером строки: cl.h:103) -> Enter
@@ -69,22 +72,85 @@ int main() {
         // Аналогично тому, как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
         std::vector<unsigned char> platformName(platformNameSize, 0);
         // clGetPlatformInfo(...);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), nullptr));
         std::cout << "    Platform name: " << platformName.data() << std::endl;
 
         // TODO 1.3
         // Запросите и напечатайте так же в консоль вендора данной платформы
+        size_t platformVendorSize = 0;
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &platformVendorSize));
+        std::vector<unsigned char> platformVendor(platformVendorSize, 0);
+        OCL_SAFE_CALL(
+                clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, platformVendorSize, platformVendor.data(), nullptr));
+        std::cout << "    Platform vendor: " << platformVendor.data() << std::endl;
 
         // TODO 2.1
         // Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
         cl_uint devicesCount = 0;
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
+        std::cout << "    Number of devices: " << devicesCount << std::endl;
 
         for (int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex) {
             // TODO 2.2
             // Запросите и напечатайте в консоль:
+            cl_device_id device;
+            OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, nullptr));
+
+
             // - Название устройства
+            size_t deviceNameSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, 0, nullptr, &deviceNameSize));
+            std::vector<unsigned char> deviceName(deviceNameSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, deviceNameSize, deviceName.data(), nullptr));
+            std::cout << "        Device name: " << deviceName.data() << std::endl;
+
             // - Тип устройства (видеокарта/процессор/что-то странное)
+            cl_device_type deviceType;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(deviceType), &deviceType, nullptr));
+            switch (deviceType) {
+                case CL_DEVICE_TYPE_GPU:
+                    std::cout << "        Device type: " << "GPU" << std::endl;
+                    break;
+                case CL_DEVICE_TYPE_CPU:
+                    std::cout << "        Device type: " << "CPU" << std::endl;
+                    break;
+                case CL_DEVICE_TYPE_ACCELERATOR:
+                    std::cout << "        Device type: " << "ACCELERATOR" << std::endl;
+                    break;
+                default:
+                    std::cout << "        Device type: " << "UNKNOWN" << std::endl;
+                    break;
+            }
+
             // - Размер памяти устройства в мегабайтах
+            cl_ulong deviceMemorySize;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(deviceMemorySize),
+                                          &deviceMemorySize, nullptr));
+            std::cout << "        Device memory size: " << deviceMemorySize / (1024 * 1024) << " MB" << std::endl;
+
+            cl_ulong deviceMemSizeBytes;
+            OCL_SAFE_CALL(
+                    clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(cl_ulong), &deviceMemSizeBytes, nullptr));
+            std::cout << "        Device mem size: " << deviceMemSizeBytes / 1000000.f << " MB" << std::endl;
+
             // - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+            size_t deviceExtensionsSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, 0, nullptr, &deviceExtensionsSize));
+            std::vector<unsigned char> deviceExtensions(deviceExtensionsSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, deviceExtensionsSize, deviceExtensions.data(),
+                                          nullptr));
+            std::cout << "        Device extensions: " << deviceExtensions.data() << std::endl;
+
+            size_t deviceVersionSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VERSION, 0, nullptr, &deviceVersionSize));
+            std::vector<unsigned char> deviceVersion(deviceVersionSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_VERSION, deviceVersionSize, deviceVersion.data(), nullptr));
+            std::cout << "        OpenCL version: " << deviceVersion.data() << std::endl;
+
+            cl_uint maxComputeUnits;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(maxComputeUnits),
+                                          &maxComputeUnits, nullptr));
+            std::cout << "        Max compute units: " << maxComputeUnits << std::endl;
         }
     }
 


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
 ./build/aplusb        
Data generated for n=100000000!
#ifdef __CLION_IDE__
    // Этот include виден только для CLion парсера, это позволяет IDE "знать" ключевые слова вроде __kernel, __global
    // а также уметь подсказывать OpenCL методы, описанные в данном инклюде (такие как get_global_id(...) и get_local_id(...))
    #include "clion_defines.cl"
#endif

#line 8// Седьмая строчка теперь восьмая (при ошибках компиляции в логе компиляции будут указаны корректные строчки благодаря этой директиве)

// TODO 5 реализуйте кернел:
// - От обычной функции кернел отличается модификатором __kernel и тем, что возвращаемый тип всегда void
// - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
// - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)

__kernel void aplusb(__global const float as[], __global const float bs[], __global float cs[], unsigned int n) {
    // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
    // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
    // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
    unsigned int id = get_global_id(0);
    if (id >= n)
        return;
    cs[id] = as[id] + bs[id];

    // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
    // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)
    // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,
    // либо сделать return в кернеле до обращения к данным в тех WorkItems, где get_global_id(0) выходит за границы данных (явной проверкой)
}

Kernel average time: 0.0204067+-3.00919e-05 s
GFlops: 4.90034
VRAM bandwidth: 49.0034 GB/s
Result data transfer time: 0.025329+-0.00212045 s
VRAM -> RAM bandwidth: 14.7076 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./build/aplusb
Data generated for n=100000000!
#ifdef __CLION_IDE__
    // Этот include виден только для CLion парсера, это позволяет IDE "знать" ключевые слова вроде __kernel, __global
    // а также уметь подсказывать OpenCL методы, описанные в данном инклюде (такие как get_global_id(...) и get_local_id(...))
    #include "clion_defines.cl"
#endif

#line 8// Седьмая строчка теперь восьмая (при ошибках компиляции в логе компиляции будут указаны корректные строчки благодаря этой директиве)

// TODO 5 реализуйте кернел:
// - От обычной функции кернел отличается модификатором __kernel и тем, что возвращаемый тип всегда void
// - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
// - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)

__kernel void aplusb(__global const float as[], __global const float bs[], __global float cs[], unsigned int n) {
    // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
    // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
    // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
    unsigned int id = get_global_id(0);
    if (id >= n)
        return;
    cs[id] = as[id] + bs[id];

    // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
    // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)
    // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,
    // либо сделать return в кернеле до обращения к данным в тех WorkItems, где get_global_id(0) выходит за границы данных (явной проверкой)
}

Log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <aplusb> was successfully vectorized (8)
Done.
Kernel average time: 0.034[6](https://github.com/GPGPUCourse/GPGPUTasks2024/actions/runs/13902631914/job/38897934368?pr=344#step:7:7)85+-0.00030173 s
GFlops: 2.88309
VRAM bandwidth: 28.8309 GB/s
Result data transfer time: 0.0184304+-0.000612009 s
VRAM -> RAM bandwidth: 20.212[7](https://github.com/GPGPUCourse/GPGPUTasks2024/actions/runs/13902631914/job/38897934368?pr=344#step:7:8) GB/s
</pre>

</p></details>